### PR TITLE
feat(repair): passive CDN health checks for Ok torrents

### DIFF
--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -14,6 +14,12 @@ pub(super) fn default_repair_timeout_mins() -> u64 {
 pub(super) fn default_stalled_download_mins() -> u64 {
     10
 }
+pub(super) fn default_head_unreachable_threshold() -> usize {
+    1
+}
+pub(super) fn default_head_check_min_interval_mins() -> u64 {
+    30
+}
 pub(super) fn default_rate_limit() -> u32 {
     250
 }

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -62,6 +62,18 @@ pub struct RepairConfig {
 
     #[serde(default)]
     pub delete_error_torrents: bool,
+
+    /// Periodically probe unrestricted CDN URLs (HEAD or range per `[api]`) for playable files.
+    #[serde(default = "defaults::bool_true")]
+    pub head_check_enabled: bool,
+
+    /// Enqueue repair when passive HEAD finds at least this many bad slots (≥ 1).
+    #[serde(default = "defaults::default_head_unreachable_threshold")]
+    pub head_unreachable_threshold: usize,
+
+    /// Minimum wall time between passive HEAD runs for the same torrent.
+    #[serde(default = "defaults::default_head_check_min_interval_mins")]
+    pub head_check_min_interval_mins: u64,
 }
 
 impl Default for RepairConfig {
@@ -73,6 +85,9 @@ impl Default for RepairConfig {
             stalled_download_mins: 10,
             restrict_to_cached: false,
             delete_error_torrents: false,
+            head_check_enabled: true,
+            head_unreachable_threshold: 1,
+            head_check_min_interval_mins: 30,
         }
     }
 }

--- a/src/repair/detect.rs
+++ b/src/repair/detect.rs
@@ -3,8 +3,16 @@
 use std::collections::HashSet;
 
 use crate::db::TorrentState;
-use crate::rd::types::{Torrent, TorrentInfo};
+use crate::rd::RealDebrid;
+use crate::rd::api::UnrestrictCache;
+use crate::rd::client::{ApiError, RdError};
+use crate::rd::types::{File, Torrent, TorrentInfo};
 use crate::torrent::ManagedTorrent;
+
+fn verify_failed_like_bandwidth(e: &anyhow::Error) -> bool {
+    let m = e.to_string().to_lowercase();
+    m.contains("traffic") || m.contains("bandwidth") || m.contains("fair usage")
+}
 
 /// Selected-file index `i` should have `links[i]` non-empty (matches FUSE link resolution).
 /// Same rule as the repair engine periodic scan: eligible for repair work (not skipped as unrepairable).
@@ -23,6 +31,60 @@ pub fn periodic_repair_eligible(mt: &ManagedTorrent) -> bool {
     mt.state == TorrentState::Broken
         || mt.state == TorrentState::UnderRepair
         || (mt.state == TorrentState::Ok && (unassigned || file_broken))
+}
+
+/// How many selected **playable** files have a non-empty RD link slot (same index rule as FUSE).
+/// Used to decide whether passive HEAD probing can run and for tests.
+pub fn passive_head_probe_slot_count(info: &TorrentInfo) -> usize {
+    let selected: Vec<&File> = info.files.iter().filter(|f| f.is_selected()).collect();
+    let mut n = 0usize;
+    for (sel_i, file) in selected.iter().enumerate() {
+        if !path_looks_playable(&file.path) {
+            continue;
+        }
+        if info.links.get(sel_i).is_some_and(|s| !s.is_empty()) {
+            n += 1;
+        }
+    }
+    n
+}
+
+/// Passive link health: unrestrict each playable selected RD link, then `verify_link` on the CDN URL.
+/// Returns how many slots failed (treats unrestrict/verify failures like preflight, except bandwidth → `Err`).
+pub async fn check_head_unreachable(
+    rd: &RealDebrid,
+    cache: &UnrestrictCache,
+    info: &TorrentInfo,
+) -> Result<usize, RdError> {
+    let mut unreachable = 0usize;
+    let selected: Vec<&File> = info.files.iter().filter(|f| f.is_selected()).collect();
+    for (sel_i, file) in selected.iter().enumerate() {
+        if !path_looks_playable(&file.path) {
+            continue;
+        }
+        let Some(link) = info.links.get(sel_i).filter(|s| !s.is_empty()) else {
+            continue;
+        };
+        match rd.unrestrict_link(cache, link).await {
+            Ok(dl) => {
+                if let Err(e) = rd.verify_link(&dl.download).await {
+                    if verify_failed_like_bandwidth(&e) {
+                        return Err(RdError::Api(ApiError::TrafficExhausted {
+                            message: e.to_string(),
+                        }));
+                    }
+                    unreachable += 1;
+                }
+            }
+            Err(e) => {
+                if e.is_bandwidth_limited() {
+                    return Err(e);
+                }
+                unreachable += 1;
+            }
+        }
+    }
+    Ok(unreachable)
 }
 
 pub fn unassigned_selected_link_count(info: &TorrentInfo) -> usize {

--- a/src/repair/engine/mod.rs
+++ b/src/repair/engine/mod.rs
@@ -1,11 +1,13 @@
 //! Background repair loop: throttled periodic scan, priority queue, single-flight sessions.
 
+mod passive_head;
 mod repair_one;
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
+use dashmap::DashMap;
 use tokio::sync::Mutex;
 use tokio::time;
 use tokio_util::sync::CancellationToken;
@@ -25,6 +27,8 @@ pub struct RepairEngine {
     pub config: Arc<ArcSwap<Config>>,
     pub torrent_manager: Arc<TorrentManager>,
     pub(crate) shutdown: CancellationToken,
+    /// Last passive HEAD probe time per `access_key` (throttles `head_check_min_interval_mins`).
+    pub(super) passive_head_last: DashMap<String, std::time::Instant>,
     session: Mutex<()>,
 }
 
@@ -42,6 +46,7 @@ impl RepairEngine {
             config,
             torrent_manager,
             shutdown,
+            passive_head_last: DashMap::new(),
             session: Mutex::new(()),
         }
     }
@@ -76,6 +81,7 @@ impl RepairEngine {
         if periodic {
             let mut skipped_unrepairable = 0usize;
             let mut periodic_eligible = 0usize;
+            let mut head_check_enqueued = 0usize;
             for e in self.torrent_manager.torrents.iter() {
                 let mt = e.value();
                 if mt.unrepairable_reason.is_some() {
@@ -87,9 +93,19 @@ impl RepairEngine {
                     keys.push(mt.access_key.clone());
                 }
             }
+
+            head_check_enqueued += passive_head::append_passive_head_candidates(
+                &self.rd,
+                &self.torrent_manager,
+                &self.passive_head_last,
+                &cfg.repair,
+                &mut keys,
+            )
+            .await;
+
             info!(
                 periodic_eligible,
-                skipped_unrepairable, "Repair engine: periodic candidate scan"
+                skipped_unrepairable, head_check_enqueued, "Repair engine: periodic candidate scan"
             );
         }
 

--- a/src/repair/engine/passive_head.rs
+++ b/src/repair/engine/passive_head.rs
@@ -1,0 +1,105 @@
+//! Passive CDN probe during periodic repair scan (`repair.head_check_*`).
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use tracing::{info, warn};
+
+use crate::config::RepairConfig;
+use crate::db::TorrentState;
+use crate::rd::RealDebrid;
+use crate::torrent::TorrentManager;
+
+use super::super::detect::{
+    check_head_unreachable, passive_head_probe_slot_count, periodic_repair_eligible,
+};
+
+/// Returns how many torrents were appended to `keys` from passive HEAD failures.
+pub(super) async fn append_passive_head_candidates(
+    rd: &Arc<RealDebrid>,
+    torrent_manager: &Arc<TorrentManager>,
+    passive_head_last: &DashMap<String, Instant>,
+    repair: &RepairConfig,
+    keys: &mut Vec<String>,
+) -> usize {
+    if !repair.head_check_enabled {
+        return 0;
+    }
+
+    let interval = Duration::from_secs(repair.head_check_min_interval_mins.max(1) * 60);
+    let threshold = repair.head_unreachable_threshold.max(1);
+    let mut head_candidates: Vec<String> = Vec::new();
+
+    for e in torrent_manager.torrents.iter() {
+        let mt = e.value();
+        if mt.unrepairable_reason.is_some() {
+            continue;
+        }
+        if periodic_repair_eligible(mt) {
+            continue;
+        }
+        if mt.state != TorrentState::Ok {
+            continue;
+        }
+        let Some(info) = mt.info.as_ref() else {
+            continue;
+        };
+        if passive_head_probe_slot_count(info) == 0 {
+            continue;
+        }
+        let k = mt.access_key.clone();
+        if let Some(last) = passive_head_last.get(&k)
+            && last.value().elapsed() < interval
+        {
+            continue;
+        }
+        head_candidates.push(k);
+    }
+
+    let rd = rd.clone();
+    let cache = torrent_manager.unrestrict_cache.clone();
+    let mut head_check_enqueued = 0usize;
+
+    for access_key in head_candidates {
+        let Some(mt_ent) = torrent_manager.torrents.get(&access_key) else {
+            continue;
+        };
+        let mt = mt_ent.value().clone();
+        drop(mt_ent);
+        let Some(info) = mt.info.clone() else {
+            continue;
+        };
+        match check_head_unreachable(&rd, &cache, &info).await {
+            Ok(n) => {
+                passive_head_last.insert(access_key.clone(), Instant::now());
+                if n >= threshold {
+                    head_check_enqueued += 1;
+                    keys.push(access_key.clone());
+                    info!(
+                        access_key = %access_key,
+                        unreachable_links = n,
+                        "Repair engine: passive HEAD check found unreachable links"
+                    );
+                }
+            }
+            Err(e) if e.is_bandwidth_limited() => {
+                passive_head_last.insert(access_key.clone(), Instant::now());
+                warn!(
+                    access_key = %access_key,
+                    "Repair engine: passive HEAD check deferred (bandwidth)"
+                );
+            }
+            Err(e) => {
+                passive_head_last.insert(access_key.clone(), Instant::now());
+                warn!(
+                    access_key = %access_key,
+                    error = %e,
+                    "Repair engine: passive HEAD check error"
+                );
+            }
+        }
+    }
+
+    head_check_enqueued
+}

--- a/src/repair/mod.rs
+++ b/src/repair/mod.rs
@@ -6,8 +6,9 @@ pub mod reasons;
 pub mod strategies;
 
 pub use detect::{
-    duplicate_selected_file_ids, has_non_playable_selected, is_stalled_download,
-    path_looks_playable, unassigned_selected_link_count,
+    check_head_unreachable, duplicate_selected_file_ids, has_non_playable_selected,
+    is_stalled_download, passive_head_probe_slot_count, path_looks_playable,
+    unassigned_selected_link_count,
 };
 
 use serde::{Deserialize, Serialize};

--- a/tests/head_check_tests.rs
+++ b/tests/head_check_tests.rs
@@ -1,0 +1,96 @@
+//! Passive HEAD probe helpers (`repair::detect`).
+
+use chrono::Utc;
+use rd_rs::config::Config;
+use rd_rs::rd::RealDebrid;
+use rd_rs::rd::api::new_unrestrict_cache;
+use rd_rs::rd::types::{File, TorrentInfo};
+use rd_rs::repair::{check_head_unreachable, passive_head_probe_slot_count};
+
+fn torrent_info(links: &[&str], files: &[(String, i32)]) -> TorrentInfo {
+    TorrentInfo {
+        id: "tid".into(),
+        name: "name.mkv".into(),
+        hash: "deadbeef".into(),
+        progress: 100,
+        status: "downloaded".into(),
+        added: Utc::now(),
+        ended: None,
+        bytes: 0,
+        links: links.iter().map(|s| (*s).to_string()).collect(),
+        original_name: String::new(),
+        original_bytes: 0,
+        files: files
+            .iter()
+            .enumerate()
+            .map(|(i, (path, selected))| File {
+                id: i as i32,
+                path: path.clone(),
+                bytes: 0,
+                selected: *selected,
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn passive_head_probe_slot_count_skips_non_playable() {
+    let info = torrent_info(
+        &["https://real-debrid.com/d/abc"],
+        &[("/readme.txt".into(), 1)],
+    );
+    assert_eq!(passive_head_probe_slot_count(&info), 0);
+}
+
+#[test]
+fn passive_head_probe_slot_count_counts_mkv_with_link() {
+    let info = torrent_info(
+        &["https://real-debrid.com/d/abc"],
+        &[("/movie.mkv".into(), 1)],
+    );
+    assert_eq!(passive_head_probe_slot_count(&info), 1);
+}
+
+#[test]
+fn passive_head_probe_slot_count_empty_link_not_counted() {
+    let info = torrent_info(&[""], &[("/movie.mkv".into(), 1)]);
+    assert_eq!(passive_head_probe_slot_count(&info), 0);
+}
+
+#[test]
+fn passive_head_probe_slot_count_two_playable_two_links() {
+    let info = torrent_info(
+        &["https://a", "https://b"],
+        &[
+            ("/a.mkv".into(), 1),
+            ("/b.mkv".into(), 1),
+            ("/extra.nfo".into(), 0),
+        ],
+    );
+    assert_eq!(passive_head_probe_slot_count(&info), 2);
+}
+
+fn test_config() -> Config {
+    let toml = r#"
+token = "dummy-token-for-tests"
+mount_path = "/tmp/rd-rs-mount"
+cache_dir = "/tmp/rd-rs-cache"
+"#;
+    toml::from_str(toml).expect("parse test config")
+}
+
+#[tokio::test]
+async fn check_head_unreachable_returns_zero_when_no_probe_slots() {
+    let cfg = test_config();
+    let rd = RealDebrid::new(&cfg).expect("RealDebrid");
+    let cache = new_unrestrict_cache();
+    // Non-playable selected file: loop never calls unrestrict / verify (no outbound HTTP).
+    let info = torrent_info(
+        &["https://real-debrid.com/d/abc"],
+        &[("/notes.txt".into(), 1)],
+    );
+    let n = check_head_unreachable(&rd, &cache, &info)
+        .await
+        .expect("probe");
+    assert_eq!(n, 0);
+}


### PR DESCRIPTION
Add periodic unrestrict + verify_link probing for playable selected files, throttled per torrent and gated by head_check_* repair config. Enqueue repair when failures meet head_unreachable_threshold.

Extract passive scan into repair/engine/passive_head.rs; add passive_head_probe_slot_count and tests/head_check_tests.rs.