### PR TITLE
Part 6/11: feat(api): traffic/details snapshot per token; fix cache get_or_create race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target
 zurg_rs_plan.md
 config.toml
-docs/zurg-main-review.md
+docs/*.md
 data/
 .cursor/
 .cursorignore

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicI32, AtomicI64, Ordering};
 use std::time::Duration;
 
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 use tokio::time;
 
 use crate::cache::item::CacheItem;
@@ -78,6 +79,10 @@ impl Cache {
         format!("{access_key}/{filename}")
     }
 
+    /// Returns the live [`CacheItem`] for `key`, creating it on first use.
+    ///
+    /// Uses `DashMap::entry` so concurrent callers share one canonical `Arc` instead of
+    /// duplicating items (Decypharr B3-style creation race).
     pub fn get_or_create(
         &self,
         access_key: &str,
@@ -86,16 +91,21 @@ impl Cache {
     ) -> anyhow::Result<Arc<CacheItem>> {
         let key = Self::build_key(access_key, filename);
 
-        if let Some(item) = self.items.get(&key) {
-            return Ok(Arc::clone(item.value()));
+        match self.items.entry(key.clone()) {
+            Entry::Occupied(o) => Ok(Arc::clone(o.get())),
+            Entry::Vacant(v) => {
+                let path = self.cache_dir.join(access_key).join(filename);
+                let item = CacheItem::open_or_create_with_db(
+                    path,
+                    key.clone(),
+                    file_size,
+                    self.range_db.clone(),
+                )?;
+                tracing::info!(file = %filename, key = %key, "cache open");
+                let r = v.insert(item);
+                Ok(Arc::clone(r.value()))
+            }
         }
-
-        let path = self.cache_dir.join(access_key).join(filename);
-        let item =
-            CacheItem::open_or_create_with_db(path, key.clone(), file_size, self.range_db.clone())?;
-        tracing::info!(file = %filename, key = %key, "cache open");
-        self.items.entry(key).or_insert_with(|| Arc::clone(&item));
-        Ok(item)
     }
 
     /// Drop in-memory entry, remove the sparse file, and delete persisted range metadata.

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -44,6 +44,9 @@ pub(super) fn default_bandwidth_reset_timezone() -> String {
 pub(super) fn default_unrestrict_cache_sweep_interval_mins() -> u64 {
     60
 }
+pub(super) fn default_traffic_details_refresh_secs() -> u64 {
+    300
+}
 pub(super) fn default_retries() -> u32 {
     2
 }

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -141,6 +141,10 @@ pub struct ApiConfig {
     /// How often to drop in-memory unrestrict cache entries past the 4h TTL. 0 = disabled.
     #[serde(default = "defaults::default_unrestrict_cache_sweep_interval_mins")]
     pub unrestrict_cache_sweep_interval_mins: u64,
+
+    /// Poll `GET /traffic/details` for every download token this often (seconds). Default 300 (5m, zurg-style). 0 = disabled.
+    #[serde(default = "defaults::default_traffic_details_refresh_secs")]
+    pub traffic_details_refresh_secs: u64,
 }
 
 impl Default for ApiConfig {
@@ -159,6 +163,7 @@ impl Default for ApiConfig {
             download_read_timeout_secs: 300,
             bandwidth_reset_timezone: defaults::default_bandwidth_reset_timezone(),
             unrestrict_cache_sweep_interval_mins: 60,
+            traffic_details_refresh_secs: 300,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,22 @@ async fn run_fuse_mount() -> Result<()> {
         });
     }
 
+    {
+        let rd_td = rd_client.clone();
+        let config_td = config.clone();
+        tokio::spawn(async move {
+            loop {
+                let secs = config_td.load().api.traffic_details_refresh_secs;
+                if secs == 0 {
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    continue;
+                }
+                rd_td.refresh_traffic_details_snapshot().await;
+                tokio::time::sleep(std::time::Duration::from_secs(secs.max(1))).await;
+            }
+        });
+    }
+
     let mut mount_options = fuse3::MountOptions::default();
     mount_options
         .allow_other(true)

--- a/src/rd/mod.rs
+++ b/src/rd/mod.rs
@@ -8,6 +8,7 @@ pub mod bandwidth_reset;
 pub mod cdn;
 pub mod client;
 pub mod token_pool;
+pub mod traffic_snapshot;
 pub mod types;
 
 use std::sync::Arc;
@@ -18,6 +19,7 @@ use arc_swap::ArcSwap;
 use reqwest::ClientBuilder;
 
 use crate::config::Config;
+use crate::rd::types::TrafficDetailsSnapshot;
 use client::{Credentials, RateLimiter, RdClient, RdClientConfig};
 use token_pool::TokenPool;
 
@@ -40,6 +42,8 @@ pub struct RealDebrid {
     pub token_pool: Arc<TokenPool>,
     pub config: Arc<Config>,
     pub ranked_hosts: Arc<arc_swap::ArcSwapOption<cdn::RankedHosts>>,
+    /// Latest per-token `GET /traffic/details` snapshot when refresh is enabled in config.
+    pub traffic_details: Arc<arc_swap::ArcSwapOption<TrafficDetailsSnapshot>>,
     /// Shared, hot-swappable credentials. Updated atomically by [`reload_credentials`](Self::reload_credentials).
     pub credentials: Arc<ArcSwap<Credentials>>,
 }
@@ -148,6 +152,7 @@ impl RealDebrid {
             token_pool,
             config: Arc::new(cfg.clone()),
             ranked_hosts: Arc::new(arc_swap::ArcSwapOption::new(None)),
+            traffic_details: Arc::new(arc_swap::ArcSwapOption::new(None)),
             credentials,
         })
     }

--- a/src/rd/traffic_snapshot.rs
+++ b/src/rd/traffic_snapshot.rs
@@ -1,0 +1,54 @@
+//! Periodic `GET /traffic/details` per download token (zurg-style traffic refresher).
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+
+use super::RealDebrid;
+use crate::rd::types::{TrafficDetailsResponse, TrafficDetailsSnapshot};
+
+impl RealDebrid {
+    /// Fetches `/traffic/details` once per token in the pool and stores the result in
+    /// [`Self::traffic_details`]. Failed tokens are skipped with a warning.
+    pub async fn refresh_traffic_details_snapshot(&self) {
+        let base = self.config.api.base_url.trim_end_matches('/');
+        let url = format!("{base}/rest/1.0/traffic/details");
+        let tokens = self.token_pool.tokens_in_order();
+        let mut by_token = Vec::with_capacity(tokens.len());
+        for token in tokens {
+            match self.fetch_traffic_details_token(token.as_str(), &url).await {
+                Ok(details) => {
+                    tracing::debug!(
+                        days = details.len(),
+                        "traffic/details refreshed for one token slot"
+                    );
+                    by_token.push((token, details));
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    "traffic/details failed for one token slot; skipping"
+                ),
+            }
+        }
+        self.traffic_details
+            .store(Some(Arc::new(TrafficDetailsSnapshot {
+                fetched_at: Utc::now(),
+                by_token,
+            })));
+    }
+
+    async fn fetch_traffic_details_token(
+        &self,
+        token: &str,
+        url: &str,
+    ) -> Result<TrafficDetailsResponse> {
+        let resp = self
+            .api_client
+            .execute_with_fixed_bearer(token, |_| self.api_client.client.get(url))
+            .await
+            .context("traffic/details HTTP")?;
+        let t: TrafficDetailsResponse = resp.json().await.context("traffic/details decode")?;
+        Ok(t)
+    }
+}

--- a/src/rd/types.rs
+++ b/src/rd/types.rs
@@ -4,6 +4,8 @@
 //! but are actually **Europe/Paris** local time. We parse them accordingly
 //! via `parse_paris_time` and store all times as `DateTime<Utc>`.
 
+use std::sync::Arc;
+
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Europe::Paris;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -204,15 +206,26 @@ pub struct ActiveTorrentCountResponse {
 
 // ─── Traffic ──────────────────────────────────────────────────────────────────
 
-/// Response from `GET /rest/1.0/traffic/details`.
-/// It's a map of host -> TrafficHost.
-pub type TrafficDetailsResponse = std::collections::HashMap<String, TrafficHost>;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TrafficHost {
+/// One day bucket in `GET /rest/1.0/traffic/details` (API keys are ISO dates, e.g. `2015-12-09`).
+///
+/// Not to be confused with `GET /rest/1.0/traffic` (host limits); `/details` is usage **by day**.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TrafficDetailDay {
+    /// Per-host byte totals for that day.
+    #[serde(default)]
+    pub host: std::collections::HashMap<String, i64>,
+    #[serde(default)]
     pub bytes: i64,
-    pub links: i64,
-    pub reset: i64,
+}
+
+/// Response from `GET /rest/1.0/traffic/details`: date string → that day’s host breakdown + total bytes.
+pub type TrafficDetailsResponse = std::collections::HashMap<String, TrafficDetailDay>;
+
+/// In-memory snapshot of [`TrafficDetailsResponse`] for each configured download token (primary first).
+#[derive(Debug, Clone)]
+pub struct TrafficDetailsSnapshot {
+    pub fetched_at: DateTime<Utc>,
+    pub by_token: Vec<(Arc<String>, TrafficDetailsResponse)>,
 }
 
 // ─── Downloads ────────────────────────────────────────────────────────────────

--- a/tests/cache_get_or_create_tests.rs
+++ b/tests/cache_get_or_create_tests.rs
@@ -1,0 +1,23 @@
+//! Cache `get_or_create` returns a single shared item per key.
+
+use std::sync::Arc;
+
+use rd_rs::cache::Cache;
+use rd_rs::config::VfsConfig;
+
+#[tokio::test]
+async fn get_or_create_same_arc_per_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let vfs = Arc::new(VfsConfig::default());
+    let cache = Cache::new(dir.path(), vfs);
+    let a = cache
+        .get_or_create("ak", "movie.mkv", 4096)
+        .expect("first create");
+    let b = cache
+        .get_or_create("ak", "movie.mkv", 4096)
+        .expect("second get");
+    assert!(
+        Arc::ptr_eq(&a, &b),
+        "get_or_create must return the same Arc as the live map entry"
+    );
+}

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -13,6 +13,7 @@ fn parse_minimal_toml() {
     assert_eq!(cfg.api.download_read_timeout_secs, 300);
     assert_eq!(cfg.api.bandwidth_reset_timezone, "Europe/Paris");
     assert_eq!(cfg.api.unrestrict_cache_sweep_interval_mins, 60);
+    assert_eq!(cfg.api.traffic_details_refresh_secs, 300);
     assert_eq!(cfg.repair.every_mins, 60);
     assert_eq!(cfg.vfs.chunk_size, "4M");
 }

--- a/tests/traffic_details_tests.rs
+++ b/tests/traffic_details_tests.rs
@@ -1,0 +1,40 @@
+//! Tests for traffic / bandwidth JSON types.
+
+use rd_rs::rd::types::{TrafficDetailDay, TrafficDetailsResponse};
+
+#[test]
+fn deserialize_traffic_details_per_day_shape() {
+    let json = r#"{
+        "2015-12-09": {
+            "host": { "uptobox.com": 11066701819 },
+            "bytes": 11066701819
+        },
+        "2015-12-08": {
+            "host": { "uptobox.com": 872664221 },
+            "bytes": 872664221
+        }
+    }"#;
+    let m: TrafficDetailsResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(m.len(), 2);
+    let d = m.get("2015-12-09").unwrap();
+    assert_eq!(d.bytes, 11066701819);
+    assert_eq!(d.host.get("uptobox.com").copied(), Some(11066701819));
+}
+
+#[test]
+fn traffic_detail_day_roundtrip() {
+    let d = TrafficDetailDay {
+        host: [("x.com".into(), 42)].into_iter().collect(),
+        bytes: 42,
+    };
+    let s = serde_json::to_string(&d).unwrap();
+    let back: TrafficDetailDay = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.bytes, d.bytes);
+    assert_eq!(back.host.get("x.com").copied(), Some(42));
+}
+
+#[test]
+fn deserialize_empty_traffic_details_object() {
+    let m: TrafficDetailsResponse = serde_json::from_str("{}").unwrap();
+    assert!(m.is_empty());
+}


### PR DESCRIPTION
This is part 6 of 11 in the cumulative PR chain. 

Current PR contains all architectural changes from part 1 up to 6 against `main`.