### PR TITLE
Part 7/11: fix(fuse): cancel reads on FUSE interrupt and tie workers to fh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target
 zurg_rs_plan.md
 config.toml
-docs/zurg-main-review.md
+docs/*.md
 data/
 .cursor/
 .cursorignore

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicI32, AtomicI64, Ordering};
 use std::time::Duration;
 
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 use tokio::time;
 
 use crate::cache::item::CacheItem;
@@ -78,6 +79,10 @@ impl Cache {
         format!("{access_key}/{filename}")
     }
 
+    /// Returns the live [`CacheItem`] for `key`, creating it on first use.
+    ///
+    /// Uses `DashMap::entry` so concurrent callers share one canonical `Arc` instead of
+    /// duplicating items (Decypharr B3-style creation race).
     pub fn get_or_create(
         &self,
         access_key: &str,
@@ -86,16 +91,21 @@ impl Cache {
     ) -> anyhow::Result<Arc<CacheItem>> {
         let key = Self::build_key(access_key, filename);
 
-        if let Some(item) = self.items.get(&key) {
-            return Ok(Arc::clone(item.value()));
+        match self.items.entry(key.clone()) {
+            Entry::Occupied(o) => Ok(Arc::clone(o.get())),
+            Entry::Vacant(v) => {
+                let path = self.cache_dir.join(access_key).join(filename);
+                let item = CacheItem::open_or_create_with_db(
+                    path,
+                    key.clone(),
+                    file_size,
+                    self.range_db.clone(),
+                )?;
+                tracing::info!(file = %filename, key = %key, "cache open");
+                let r = v.insert(item);
+                Ok(Arc::clone(r.value()))
+            }
         }
-
-        let path = self.cache_dir.join(access_key).join(filename);
-        let item =
-            CacheItem::open_or_create_with_db(path, key.clone(), file_size, self.range_db.clone())?;
-        tracing::info!(file = %filename, key = %key, "cache open");
-        self.items.entry(key).or_insert_with(|| Arc::clone(&item));
-        Ok(item)
     }
 
     /// Drop in-memory entry, remove the sparse file, and delete persisted range metadata.

--- a/src/cache/download_session.rs
+++ b/src/cache/download_session.rs
@@ -7,7 +7,13 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-pub(crate) struct DownloadSession {
+use tokio_util::sync::CancellationToken;
+
+/// Shared downloader session for a prefetch window.
+///
+/// This is a low-level cache primitive (used by `CacheItem::read_at`). It is public only so
+/// integration tests can validate cancellation / abort behavior.
+pub struct DownloadSession {
     /// First byte passed to `run_downloader` as `start`.
     anchor: u64,
     /// Exclusive end of this prefetch pass: `(read_end + read_ahead).min(file_size)` from the
@@ -15,15 +21,17 @@ pub(crate) struct DownloadSession {
     fetch_until: u64,
     waiters: AtomicUsize,
     abort: Mutex<Option<tokio::task::AbortHandle>>,
+    cancel: CancellationToken,
 }
 
 impl DownloadSession {
-    pub(crate) fn new(anchor: u64, fetch_until: u64) -> Self {
+    pub fn new(anchor: u64, fetch_until: u64) -> Self {
         Self {
             anchor,
             fetch_until,
             waiters: AtomicUsize::new(0),
             abort: Mutex::new(None),
+            cancel: CancellationToken::new(),
         }
     }
 
@@ -32,20 +40,25 @@ impl DownloadSession {
         offset >= self.anchor && offset < self.fetch_until
     }
 
-    pub(crate) fn set_abort_handle(&self, h: tokio::task::AbortHandle) {
+    pub fn set_abort_handle(&self, h: tokio::task::AbortHandle) {
         *self
             .abort
             .lock()
             .expect("download session abort mutex poisoned") = Some(h);
     }
+
+    pub(crate) fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
 }
 
-pub(crate) struct WaiterGuard {
+/// RAII waiter counter; last drop cancels + aborts the session.
+pub struct WaiterGuard {
     session: Arc<DownloadSession>,
 }
 
 impl WaiterGuard {
-    pub(crate) fn new(session: Arc<DownloadSession>) -> Self {
+    pub fn new(session: Arc<DownloadSession>) -> Self {
         session.waiters.fetch_add(1, Ordering::SeqCst);
         Self { session }
     }
@@ -55,6 +68,7 @@ impl Drop for WaiterGuard {
     fn drop(&mut self) {
         let prev = self.session.waiters.fetch_sub(1, Ordering::SeqCst);
         if prev == 1 {
+            self.session.cancel.cancel();
             let mut g = self
                 .session
                 .abort

--- a/src/cache/item_read_at.rs
+++ b/src/cache/item_read_at.rs
@@ -150,6 +150,7 @@ fn spawn_worker(
     pause_rx: tokio::sync::watch::Receiver<bool>,
 ) -> (tokio::task::JoinHandle<()>, Arc<DownloadSession>) {
     let session = Arc::new(DownloadSession::new(offset, fetch_until));
+    let cancel = session.cancel_token();
 
     let live_download_url = Arc::new(RwLock::new(download.download.clone()));
     let link_refresh_lock = Arc::new(Mutex::new(()));
@@ -193,6 +194,7 @@ fn spawn_worker(
                 link_refresh_lock: Arc::clone(&link_refresh_lock),
                 heal_remaining: Arc::clone(&heal_remaining),
                 pause_rx,
+                cancel,
             },
         )
         .await

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -8,7 +8,7 @@
 pub mod bitmap;
 #[allow(clippy::module_inception)]
 pub mod cache;
-pub(crate) mod download_session;
+pub mod download_session;
 mod eviction;
 pub mod item;
 pub(crate) mod item_read_at;

--- a/src/cache/worker.rs
+++ b/src/cache/worker.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{self, Duration};
+use tokio_util::sync::CancellationToken;
 
 /// If no bytes are written to cache for this duration, cancel the in-flight
 /// HTTP stream attempt and retry from the same offset.
@@ -48,6 +49,7 @@ pub(crate) struct DownloaderArgs {
     pub link_refresh_lock: Arc<Mutex<()>>,
     pub heal_remaining: Arc<AtomicU32>,
     pub pause_rx: tokio::sync::watch::Receiver<bool>,
+    pub cancel: CancellationToken,
 }
 
 /// HTTP Range GET pool for `[start, file_end)` using concurrent connection chunking
@@ -66,6 +68,7 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
         link_refresh_lock,
         heal_remaining,
         pause_rx,
+        cancel,
     } = args;
 
     // Apply read-ahead: download further than strictly needed.
@@ -109,12 +112,19 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
         let item_clone = Arc::clone(item);
         let mut p_rx = pause_rx.clone();
         let mult = Arc::clone(&shared_multiplier);
+        let cancel = cancel.clone();
 
         join_set.spawn(async move {
 
             loop {
+                if cancel.is_cancelled() {
+                    break Ok::<(), anyhow::Error>(());
+                }
                 if *p_rx.borrow() {
-                    let _ = p_rx.changed().await;
+                    tokio::select! {
+                        _ = cancel.cancelled() => break Ok::<(), anyhow::Error>(()),
+                        _ = p_rx.changed() => {}
+                    }
                 }
 
                 let chunk_opt = {
@@ -136,9 +146,16 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                 let mut retries = 0;
 
                 loop {
+                    if cancel.is_cancelled() {
+                        return Ok::<(), anyhow::Error>(());
+                    }
                     // Acquire global RD semaphore permit!
-                    let _permit = rd_clone.connection_semaphore.acquire().await
-                        .map_err(|e| anyhow::anyhow!("Semaphore closed: {}", e))?;
+                    let _permit = tokio::select! {
+                        _ = cancel.cancelled() => return Ok::<(), anyhow::Error>(()),
+                        p = rd_clone.connection_semaphore.acquire() => {
+                            p.map_err(|e| anyhow::anyhow!("Semaphore closed: {}", e))?
+                        }
+                    };
 
                     let range_header = format!("bytes={}-{}", chunk_start, chunk_end - 1);
 
@@ -146,12 +163,16 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                     let last_progress = Arc::new(AtomicU64::new(elapsed_nanos()));
                     let lp_clone = Arc::clone(&last_progress);
                     let (watchdog_tx, mut watchdog_rx) = tokio::sync::oneshot::channel::<()>();
+                    let cancel_watchdog = cancel.clone();
 
                     let watchdog = tokio::spawn(async move {
                         let mut interval = time::interval(NO_PROGRESS_CHECK);
                         let timeout_nanos = NO_PROGRESS_TIMEOUT.as_nanos() as u64;
                         loop {
                             interval.tick().await;
+                            if cancel_watchdog.is_cancelled() {
+                                return;
+                            }
                             if watchdog_tx.is_closed() { return; }
                             let last = lp_clone.load(Ordering::Acquire);
                             let now = elapsed_nanos();
@@ -242,6 +263,10 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                             }
                             continue;
                         }
+                        _ = cancel.cancelled() => {
+                            watchdog.abort();
+                            return Ok::<(), anyhow::Error>(());
+                        }
                     };
 
                     let mut chunk_bytes_downloaded = 0u64;
@@ -257,6 +282,10 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                                     "stream body stalled for {secs}s"
                                 ));
                                 break;
+                            }
+                            _ = cancel.cancelled() => {
+                                watchdog.abort();
+                                return Ok::<(), anyhow::Error>(());
                             }
                         };
 
@@ -317,7 +346,10 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                                 queue_clone.lock().push_front((new_chunk_end, chunk_end));
                                 chunk_end = new_chunk_end;
                             }
-                            time::sleep(Duration::from_secs(retries as u64 * 2)).await;
+                            tokio::select! {
+                                _ = cancel.cancelled() => return Ok::<(), anyhow::Error>(()),
+                                _ = time::sleep(Duration::from_secs(retries as u64 * 2)) => {}
+                            }
                         }
                     }
                 } // End retry loop

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -44,6 +44,9 @@ pub(super) fn default_bandwidth_reset_timezone() -> String {
 pub(super) fn default_unrestrict_cache_sweep_interval_mins() -> u64 {
     60
 }
+pub(super) fn default_traffic_details_refresh_secs() -> u64 {
+    300
+}
 pub(super) fn default_retries() -> u32 {
     2
 }

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -141,6 +141,10 @@ pub struct ApiConfig {
     /// How often to drop in-memory unrestrict cache entries past the 4h TTL. 0 = disabled.
     #[serde(default = "defaults::default_unrestrict_cache_sweep_interval_mins")]
     pub unrestrict_cache_sweep_interval_mins: u64,
+
+    /// Poll `GET /traffic/details` for every download token this often (seconds). Default 300 (5m, zurg-style). 0 = disabled.
+    #[serde(default = "defaults::default_traffic_details_refresh_secs")]
+    pub traffic_details_refresh_secs: u64,
 }
 
 impl Default for ApiConfig {
@@ -159,6 +163,7 @@ impl Default for ApiConfig {
             download_read_timeout_secs: 300,
             bandwidth_reset_timezone: defaults::default_bandwidth_reset_timezone(),
             unrestrict_cache_sweep_interval_mins: 60,
+            traffic_details_refresh_secs: 300,
         }
     }
 }

--- a/src/fuse/fs.rs
+++ b/src/fuse/fs.rs
@@ -30,11 +30,13 @@ use bytes::Bytes;
 use dashmap::DashMap;
 use fuse3::raw::prelude::*;
 use fuse3::{Errno, Result as FuseResult};
+use tokio_util::sync::CancellationToken;
 
 use crate::cache::Cache;
 use crate::config::Config;
 use crate::fuse::consts::{INODE_ALL, INODE_FILE_BASE, INODE_ROOT, INODE_TORRENT_BASE};
-use crate::fuse::vfs_read_buffer::VfsReadBuffer;
+use crate::fuse::open_file::OpenFileState;
+use crate::fuse::read_cancel_bridge::FuseReadCancelRegistration;
 use crate::rd::RealDebrid;
 use crate::rd::api::UnrestrictCache;
 use crate::torrent::{ManagedTorrent, TorrentManager};
@@ -60,7 +62,9 @@ pub struct RdFs {
     /// Next FUSE file handle for regular files (`>= 1`; `0` = no per-fd buffer).
     pub(crate) next_fh: AtomicU64,
     /// Per-`fh` read-ahead buffer for file opens (see `vfs_read_buffer`).
-    pub(crate) open_files: DashMap<u64, Arc<tokio::sync::Mutex<VfsReadBuffer>>>,
+    pub(crate) open_files: DashMap<u64, Arc<OpenFileState>>,
+    /// In-flight `read` requests by FUSE `unique` (for [`Filesystem::interrupt`] / Ctrl+C).
+    pub(crate) pending_fuse_reads: Arc<DashMap<u64, CancellationToken>>,
     /// Kernel attribute cache TTL (from `vfs.attr_timeout_secs`).
     pub(crate) attr_ttl: Duration,
     /// Kernel directory-entry cache TTL (from `vfs.entry_timeout_secs`).
@@ -94,6 +98,7 @@ impl RdFs {
             broken_read_warn_ts: DashMap::new(),
             next_fh: AtomicU64::new(1),
             open_files: DashMap::new(),
+            pending_fuse_reads: Arc::new(DashMap::new()),
             attr_ttl: Duration::from_secs(vfs.attr_timeout_secs),
             entry_ttl: Duration::from_secs(vfs.entry_timeout_secs),
         }
@@ -203,10 +208,7 @@ impl Filesystem for RdFs {
             let fh = self
                 .next_fh
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            self.open_files.insert(
-                fh,
-                Arc::new(tokio::sync::Mutex::new(VfsReadBuffer::default())),
-            );
+            self.open_files.insert(fh, Arc::new(OpenFileState::new()));
             return Ok(ReplyOpen { fh, flags: 0 });
         }
         Ok(ReplyOpen { fh: 0, flags: 0 })
@@ -221,7 +223,9 @@ impl Filesystem for RdFs {
         _lock_owner: u64,
         _flush: bool,
     ) -> FuseResult<()> {
-        self.open_files.remove(&fh);
+        if let Some((_, st)) = self.open_files.remove(&fh) {
+            st.cancel();
+        }
         Ok(())
     }
 
@@ -235,15 +239,34 @@ impl Filesystem for RdFs {
         Ok(())
     }
 
+    async fn interrupt(&self, _req: Request, unique: u64) -> FuseResult<()> {
+        if let Some((_, t)) = self.pending_fuse_reads.remove(&unique) {
+            t.cancel();
+            tracing::info!(unique, "fuse interrupt: cancelled in-flight read");
+        }
+        Ok(())
+    }
+
     async fn read(
         &self,
-        _req: Request,
+        req: Request,
         inode: u64,
         fh: u64,
         offset: u64,
         size: u32,
     ) -> FuseResult<ReplyData> {
-        let ctx = tokio_util::sync::CancellationToken::new();
+        let fh_token = self
+            .open_files
+            .get(&fh)
+            .map(|e| e.value().cancel_token())
+            .unwrap_or_default();
+
+        let _read_cancel = FuseReadCancelRegistration::new(
+            req.unique,
+            fh_token,
+            Arc::clone(&self.pending_fuse_reads),
+        );
+        let ctx = _read_cancel.token();
         super::read::read(self, inode, fh, offset, size, &self.unrestrict_cache, ctx).await
     }
 }

--- a/src/fuse/mod.rs
+++ b/src/fuse/mod.rs
@@ -20,8 +20,12 @@ mod fs_helpers;
 mod fs_lookup;
 mod fs_readdir;
 mod fs_readdirplus;
+pub mod open_file;
 pub(crate) mod read;
+mod read_cancel_bridge;
 pub mod vfs_read_buffer;
+
+pub use read_cancel_bridge::FuseReadCancelRegistration;
 
 pub use consts::{INODE_ALL, INODE_FILE_BASE, INODE_ROOT, INODE_TORRENT_BASE};
 pub use fs::RdFs;

--- a/src/fuse/open_file.rs
+++ b/src/fuse/open_file.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use super::vfs_read_buffer::VfsReadBuffer;
+
+/// Per-FUSE-file-handle state: read buffer + cancellation.
+///
+/// Cancellation is tied to the kernel file-handle lifecycle (`release`) and to
+/// each in-flight `read` via [`super::FuseReadCancelRegistration`] (FUSE
+/// `interrupt` when the client aborts a blocked read, e.g. Ctrl+C).
+pub struct OpenFileState {
+    pub buffer: Arc<tokio::sync::Mutex<VfsReadBuffer>>,
+    cancel: CancellationToken,
+}
+
+impl Default for OpenFileState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OpenFileState {
+    pub fn new() -> Self {
+        Self {
+            buffer: Arc::new(tokio::sync::Mutex::new(VfsReadBuffer::default())),
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+}

--- a/src/fuse/read.rs
+++ b/src/fuse/read.rs
@@ -141,7 +141,7 @@ pub async fn read(
         if fh != 0
             && let Some(ent) = fs.open_files.get(&fh)
         {
-            let buf = std::sync::Arc::clone(ent.value());
+            let buf = std::sync::Arc::clone(&ent.value().buffer);
             drop(ent);
             let (fill_offset, fill_len, take) = {
                 let mut g = buf.lock().await;

--- a/src/fuse/read_cancel_bridge.rs
+++ b/src/fuse/read_cancel_bridge.rs
@@ -1,0 +1,52 @@
+//! Bridge per-FUSE-request cancellation: **file handle** (`release`) vs **single syscall** (FUSE
+//! [`interrupt`](https://libfuse.github.io/doxygen/structfuse__lowlevel__ops.html)).
+//!
+//! Ctrl+C on a blocked `read()` typically sends `interrupt` before `release`; without handling it,
+//! background downloads keep running until the fd is closed.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Registers `unique` → cancel token, links cancellation to `fh_token`, and cleans up on drop.
+pub struct FuseReadCancelRegistration {
+    unique: u64,
+    pending: Arc<DashMap<u64, CancellationToken>>,
+    fh_link: JoinHandle<()>,
+    token: CancellationToken,
+}
+
+impl FuseReadCancelRegistration {
+    pub fn new(
+        unique: u64,
+        fh_token: CancellationToken,
+        pending: Arc<DashMap<u64, CancellationToken>>,
+    ) -> Self {
+        let token = CancellationToken::new();
+        pending.insert(unique, token.clone());
+        let token_fh = token.clone();
+        let fh_link = tokio::spawn(async move {
+            fh_token.cancelled().await;
+            token_fh.cancel();
+        });
+        Self {
+            unique,
+            pending,
+            fh_link,
+            token,
+        }
+    }
+
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+}
+
+impl Drop for FuseReadCancelRegistration {
+    fn drop(&mut self) {
+        self.fh_link.abort();
+        self.pending.remove(&self.unique);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,22 @@ async fn run_fuse_mount() -> Result<()> {
         });
     }
 
+    {
+        let rd_td = rd_client.clone();
+        let config_td = config.clone();
+        tokio::spawn(async move {
+            loop {
+                let secs = config_td.load().api.traffic_details_refresh_secs;
+                if secs == 0 {
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    continue;
+                }
+                rd_td.refresh_traffic_details_snapshot().await;
+                tokio::time::sleep(std::time::Duration::from_secs(secs.max(1))).await;
+            }
+        });
+    }
+
     let mut mount_options = fuse3::MountOptions::default();
     mount_options
         .allow_other(true)

--- a/src/rd/mod.rs
+++ b/src/rd/mod.rs
@@ -8,6 +8,7 @@ pub mod bandwidth_reset;
 pub mod cdn;
 pub mod client;
 pub mod token_pool;
+pub mod traffic_snapshot;
 pub mod types;
 
 use std::sync::Arc;
@@ -18,6 +19,7 @@ use arc_swap::ArcSwap;
 use reqwest::ClientBuilder;
 
 use crate::config::Config;
+use crate::rd::types::TrafficDetailsSnapshot;
 use client::{Credentials, RateLimiter, RdClient, RdClientConfig};
 use token_pool::TokenPool;
 
@@ -40,6 +42,8 @@ pub struct RealDebrid {
     pub token_pool: Arc<TokenPool>,
     pub config: Arc<Config>,
     pub ranked_hosts: Arc<arc_swap::ArcSwapOption<cdn::RankedHosts>>,
+    /// Latest per-token `GET /traffic/details` snapshot when refresh is enabled in config.
+    pub traffic_details: Arc<arc_swap::ArcSwapOption<TrafficDetailsSnapshot>>,
     /// Shared, hot-swappable credentials. Updated atomically by [`reload_credentials`](Self::reload_credentials).
     pub credentials: Arc<ArcSwap<Credentials>>,
 }
@@ -148,6 +152,7 @@ impl RealDebrid {
             token_pool,
             config: Arc::new(cfg.clone()),
             ranked_hosts: Arc::new(arc_swap::ArcSwapOption::new(None)),
+            traffic_details: Arc::new(arc_swap::ArcSwapOption::new(None)),
             credentials,
         })
     }

--- a/src/rd/traffic_snapshot.rs
+++ b/src/rd/traffic_snapshot.rs
@@ -1,0 +1,54 @@
+//! Periodic `GET /traffic/details` per download token (zurg-style traffic refresher).
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+
+use super::RealDebrid;
+use crate::rd::types::{TrafficDetailsResponse, TrafficDetailsSnapshot};
+
+impl RealDebrid {
+    /// Fetches `/traffic/details` once per token in the pool and stores the result in
+    /// [`Self::traffic_details`]. Failed tokens are skipped with a warning.
+    pub async fn refresh_traffic_details_snapshot(&self) {
+        let base = self.config.api.base_url.trim_end_matches('/');
+        let url = format!("{base}/rest/1.0/traffic/details");
+        let tokens = self.token_pool.tokens_in_order();
+        let mut by_token = Vec::with_capacity(tokens.len());
+        for token in tokens {
+            match self.fetch_traffic_details_token(token.as_str(), &url).await {
+                Ok(details) => {
+                    tracing::debug!(
+                        days = details.len(),
+                        "traffic/details refreshed for one token slot"
+                    );
+                    by_token.push((token, details));
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    "traffic/details failed for one token slot; skipping"
+                ),
+            }
+        }
+        self.traffic_details
+            .store(Some(Arc::new(TrafficDetailsSnapshot {
+                fetched_at: Utc::now(),
+                by_token,
+            })));
+    }
+
+    async fn fetch_traffic_details_token(
+        &self,
+        token: &str,
+        url: &str,
+    ) -> Result<TrafficDetailsResponse> {
+        let resp = self
+            .api_client
+            .execute_with_fixed_bearer(token, |_| self.api_client.client.get(url))
+            .await
+            .context("traffic/details HTTP")?;
+        let t: TrafficDetailsResponse = resp.json().await.context("traffic/details decode")?;
+        Ok(t)
+    }
+}

--- a/src/rd/types.rs
+++ b/src/rd/types.rs
@@ -4,6 +4,8 @@
 //! but are actually **Europe/Paris** local time. We parse them accordingly
 //! via `parse_paris_time` and store all times as `DateTime<Utc>`.
 
+use std::sync::Arc;
+
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Europe::Paris;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -204,15 +206,26 @@ pub struct ActiveTorrentCountResponse {
 
 // ─── Traffic ──────────────────────────────────────────────────────────────────
 
-/// Response from `GET /rest/1.0/traffic/details`.
-/// It's a map of host -> TrafficHost.
-pub type TrafficDetailsResponse = std::collections::HashMap<String, TrafficHost>;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TrafficHost {
+/// One day bucket in `GET /rest/1.0/traffic/details` (API keys are ISO dates, e.g. `2015-12-09`).
+///
+/// Not to be confused with `GET /rest/1.0/traffic` (host limits); `/details` is usage **by day**.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TrafficDetailDay {
+    /// Per-host byte totals for that day.
+    #[serde(default)]
+    pub host: std::collections::HashMap<String, i64>,
+    #[serde(default)]
     pub bytes: i64,
-    pub links: i64,
-    pub reset: i64,
+}
+
+/// Response from `GET /rest/1.0/traffic/details`: date string → that day’s host breakdown + total bytes.
+pub type TrafficDetailsResponse = std::collections::HashMap<String, TrafficDetailDay>;
+
+/// In-memory snapshot of [`TrafficDetailsResponse`] for each configured download token (primary first).
+#[derive(Debug, Clone)]
+pub struct TrafficDetailsSnapshot {
+    pub fetched_at: DateTime<Utc>,
+    pub by_token: Vec<(Arc<String>, TrafficDetailsResponse)>,
 }
 
 // ─── Downloads ────────────────────────────────────────────────────────────────

--- a/tests/cache_get_or_create_tests.rs
+++ b/tests/cache_get_or_create_tests.rs
@@ -1,0 +1,23 @@
+//! Cache `get_or_create` returns a single shared item per key.
+
+use std::sync::Arc;
+
+use rd_rs::cache::Cache;
+use rd_rs::config::VfsConfig;
+
+#[tokio::test]
+async fn get_or_create_same_arc_per_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let vfs = Arc::new(VfsConfig::default());
+    let cache = Cache::new(dir.path(), vfs);
+    let a = cache
+        .get_or_create("ak", "movie.mkv", 4096)
+        .expect("first create");
+    let b = cache
+        .get_or_create("ak", "movie.mkv", 4096)
+        .expect("second get");
+    assert!(
+        Arc::ptr_eq(&a, &b),
+        "get_or_create must return the same Arc as the live map entry"
+    );
+}

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -13,6 +13,7 @@ fn parse_minimal_toml() {
     assert_eq!(cfg.api.download_read_timeout_secs, 300);
     assert_eq!(cfg.api.bandwidth_reset_timezone, "Europe/Paris");
     assert_eq!(cfg.api.unrestrict_cache_sweep_interval_mins, 60);
+    assert_eq!(cfg.api.traffic_details_refresh_secs, 300);
     assert_eq!(cfg.repair.every_mins, 60);
     assert_eq!(cfg.vfs.chunk_size, "4M");
 }

--- a/tests/fuse_read_cancel_bridge_tests.rs
+++ b/tests/fuse_read_cancel_bridge_tests.rs
@@ -1,0 +1,35 @@
+//! `FuseReadCancelRegistration` — per-request cancel + fh propagation.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use rd_rs::fuse::FuseReadCancelRegistration;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn interrupt_removes_pending_and_cancels_token() {
+    let pending = Arc::new(DashMap::new());
+    let fh = CancellationToken::new();
+    let reg = FuseReadCancelRegistration::new(7, fh.clone(), Arc::clone(&pending));
+    let t = reg.token();
+    assert!(pending.contains_key(&7));
+
+    let removed = pending.remove(&7).expect("entry");
+    removed.1.cancel();
+    tokio::time::timeout(Duration::from_secs(2), t.cancelled())
+        .await
+        .expect("timeout");
+}
+
+#[tokio::test]
+async fn fh_cancel_propagates_to_read_token() {
+    let pending = Arc::new(DashMap::new());
+    let fh = CancellationToken::new();
+    let reg = FuseReadCancelRegistration::new(1, fh.clone(), Arc::clone(&pending));
+    let t = reg.token();
+    fh.cancel();
+    tokio::time::timeout(Duration::from_secs(2), t.cancelled())
+        .await
+        .expect("timeout");
+}

--- a/tests/open_file_state_tests.rs
+++ b/tests/open_file_state_tests.rs
@@ -1,0 +1,10 @@
+use rd_rs::fuse::open_file::OpenFileState;
+
+#[test]
+fn open_file_state_cancels_token() {
+    let st = OpenFileState::new();
+    let tok = st.cancel_token();
+    assert!(!tok.is_cancelled());
+    st.cancel();
+    assert!(tok.is_cancelled());
+}

--- a/tests/read_cancel_tests.rs
+++ b/tests/read_cancel_tests.rs
@@ -1,0 +1,25 @@
+//! Cancellation propagation: last waiter aborts download session promptly.
+
+use std::time::Duration;
+
+use rd_rs::cache::download_session::{DownloadSession, WaiterGuard};
+
+#[tokio::test]
+async fn last_waiter_aborts_session_task() {
+    let session = std::sync::Arc::new(DownloadSession::new(0, 1024));
+    let handle = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    });
+    session.set_abort_handle(handle.abort_handle());
+
+    {
+        let _w = WaiterGuard::new(session);
+        // Drop _w at end of scope: last waiter → cancel + abort.
+    }
+
+    let res = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    assert!(
+        res.is_ok(),
+        "session task should abort quickly after last waiter drops"
+    );
+}

--- a/tests/traffic_details_tests.rs
+++ b/tests/traffic_details_tests.rs
@@ -1,0 +1,40 @@
+//! Tests for traffic / bandwidth JSON types.
+
+use rd_rs::rd::types::{TrafficDetailDay, TrafficDetailsResponse};
+
+#[test]
+fn deserialize_traffic_details_per_day_shape() {
+    let json = r#"{
+        "2015-12-09": {
+            "host": { "uptobox.com": 11066701819 },
+            "bytes": 11066701819
+        },
+        "2015-12-08": {
+            "host": { "uptobox.com": 872664221 },
+            "bytes": 872664221
+        }
+    }"#;
+    let m: TrafficDetailsResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(m.len(), 2);
+    let d = m.get("2015-12-09").unwrap();
+    assert_eq!(d.bytes, 11066701819);
+    assert_eq!(d.host.get("uptobox.com").copied(), Some(11066701819));
+}
+
+#[test]
+fn traffic_detail_day_roundtrip() {
+    let d = TrafficDetailDay {
+        host: [("x.com".into(), 42)].into_iter().collect(),
+        bytes: 42,
+    };
+    let s = serde_json::to_string(&d).unwrap();
+    let back: TrafficDetailDay = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.bytes, d.bytes);
+    assert_eq!(back.host.get("x.com").copied(), Some(42));
+}
+
+#[test]
+fn deserialize_empty_traffic_details_object() {
+    let m: TrafficDetailsResponse = serde_json::from_str("{}").unwrap();
+    assert!(m.is_empty());
+}


### PR DESCRIPTION
This is part 7 of 11 in the cumulative PR chain. 

Current PR contains all architectural changes from part 1 up to 7 against `main`.