### PR TITLE
Part 9/11: fix(cache): clear all unrestrict buckets on CDN link heal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /target
 zurg_rs_plan.md
 config.toml
-docs/zurg-main-review.md
+docs/*.md
 data/
 .cursor/
 .cursorignore

--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicI32, AtomicI64, Ordering};
 use std::time::Duration;
 
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 use tokio::time;
 
 use crate::cache::item::CacheItem;
@@ -78,6 +79,10 @@ impl Cache {
         format!("{access_key}/{filename}")
     }
 
+    /// Returns the live [`CacheItem`] for `key`, creating it on first use.
+    ///
+    /// Uses `DashMap::entry` so concurrent callers share one canonical `Arc` instead of
+    /// duplicating items (Decypharr B3-style creation race).
     pub fn get_or_create(
         &self,
         access_key: &str,
@@ -86,16 +91,21 @@ impl Cache {
     ) -> anyhow::Result<Arc<CacheItem>> {
         let key = Self::build_key(access_key, filename);
 
-        if let Some(item) = self.items.get(&key) {
-            return Ok(Arc::clone(item.value()));
+        match self.items.entry(key.clone()) {
+            Entry::Occupied(o) => Ok(Arc::clone(o.get())),
+            Entry::Vacant(v) => {
+                let path = self.cache_dir.join(access_key).join(filename);
+                let item = CacheItem::open_or_create_with_db(
+                    path,
+                    key.clone(),
+                    file_size,
+                    self.range_db.clone(),
+                )?;
+                tracing::info!(file = %filename, key = %key, "cache open");
+                let r = v.insert(item);
+                Ok(Arc::clone(r.value()))
+            }
         }
-
-        let path = self.cache_dir.join(access_key).join(filename);
-        let item =
-            CacheItem::open_or_create_with_db(path, key.clone(), file_size, self.range_db.clone())?;
-        tracing::info!(file = %filename, key = %key, "cache open");
-        self.items.entry(key).or_insert_with(|| Arc::clone(&item));
-        Ok(item)
     }
 
     /// Drop in-memory entry, remove the sparse file, and delete persisted range metadata.

--- a/src/cache/download_session.rs
+++ b/src/cache/download_session.rs
@@ -7,7 +7,13 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-pub(crate) struct DownloadSession {
+use tokio_util::sync::CancellationToken;
+
+/// Shared downloader session for a prefetch window.
+///
+/// This is a low-level cache primitive (used by `CacheItem::read_at`). It is public only so
+/// integration tests can validate cancellation / abort behavior.
+pub struct DownloadSession {
     /// First byte passed to `run_downloader` as `start`.
     anchor: u64,
     /// Exclusive end of this prefetch pass: `(read_end + read_ahead).min(file_size)` from the
@@ -15,15 +21,17 @@ pub(crate) struct DownloadSession {
     fetch_until: u64,
     waiters: AtomicUsize,
     abort: Mutex<Option<tokio::task::AbortHandle>>,
+    cancel: CancellationToken,
 }
 
 impl DownloadSession {
-    pub(crate) fn new(anchor: u64, fetch_until: u64) -> Self {
+    pub fn new(anchor: u64, fetch_until: u64) -> Self {
         Self {
             anchor,
             fetch_until,
             waiters: AtomicUsize::new(0),
             abort: Mutex::new(None),
+            cancel: CancellationToken::new(),
         }
     }
 
@@ -32,20 +40,25 @@ impl DownloadSession {
         offset >= self.anchor && offset < self.fetch_until
     }
 
-    pub(crate) fn set_abort_handle(&self, h: tokio::task::AbortHandle) {
+    pub fn set_abort_handle(&self, h: tokio::task::AbortHandle) {
         *self
             .abort
             .lock()
             .expect("download session abort mutex poisoned") = Some(h);
     }
+
+    pub(crate) fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
 }
 
-pub(crate) struct WaiterGuard {
+/// RAII waiter counter; last drop cancels + aborts the session.
+pub struct WaiterGuard {
     session: Arc<DownloadSession>,
 }
 
 impl WaiterGuard {
-    pub(crate) fn new(session: Arc<DownloadSession>) -> Self {
+    pub fn new(session: Arc<DownloadSession>) -> Self {
         session.waiters.fetch_add(1, Ordering::SeqCst);
         Self { session }
     }
@@ -55,6 +68,7 @@ impl Drop for WaiterGuard {
     fn drop(&mut self) {
         let prev = self.session.waiters.fetch_sub(1, Ordering::SeqCst);
         if prev == 1 {
+            self.session.cancel.cancel();
             let mut g = self
                 .session
                 .abort

--- a/src/cache/item_read_at.rs
+++ b/src/cache/item_read_at.rs
@@ -150,6 +150,7 @@ fn spawn_worker(
     pause_rx: tokio::sync::watch::Receiver<bool>,
 ) -> (tokio::task::JoinHandle<()>, Arc<DownloadSession>) {
     let session = Arc::new(DownloadSession::new(offset, fetch_until));
+    let cancel = session.cancel_token();
 
     let live_download_url = Arc::new(RwLock::new(download.download.clone()));
     let link_refresh_lock = Arc::new(Mutex::new(()));
@@ -193,6 +194,7 @@ fn spawn_worker(
                 link_refresh_lock: Arc::clone(&link_refresh_lock),
                 heal_remaining: Arc::clone(&heal_remaining),
                 pause_rx,
+                cancel,
             },
         )
         .await

--- a/src/cache/link_heal.rs
+++ b/src/cache/link_heal.rs
@@ -6,15 +6,15 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use tokio::sync::{Mutex, RwLock};
 
 use crate::rd::RealDebrid;
-use crate::rd::api::{UnrestrictCache, clear_unrestrict_cache};
+use crate::rd::api::{UnrestrictCache, clear_unrestrict_cache_for_source_link};
 use crate::rd::client::RdError;
 
 /// Max automatic unrestrict refreshes per downloader session (shared across chunk workers).
-pub(crate) const MAX_SESSION_LINK_HEALS: u32 = 3;
+pub const MAX_SESSION_LINK_HEALS: u32 = 3;
 
 /// If `err` warrants it and budget remains, clear unrestrict cache, call unrestrict, update `live_url`.
 /// Returns `true` when the caller should retry the HTTP Range GET without counting a normal retry.
-pub(crate) async fn attempt_cdn_link_refresh(
+pub async fn attempt_cdn_link_refresh(
     err: &RdError,
     rd: &Arc<RealDebrid>,
     cache: &UnrestrictCache,
@@ -57,7 +57,10 @@ async fn refresh_cdn_url(
     source_link: &str,
     live_url: &RwLock<String>,
 ) -> Result<(), RdError> {
-    clear_unrestrict_cache(cache, rd.credentials.load().token.as_str(), source_link);
+    // When healing an expired CDN URL, drop *all* token buckets for this source link.
+    // The next unrestrict may use a different eligible token, and we must not reuse stale URLs
+    // from other accounts.
+    clear_unrestrict_cache_for_source_link(cache, source_link);
     let download = rd.unrestrict_link(cache, source_link).await?;
     *live_url.write().await = download.download;
     Ok(())

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -12,7 +12,7 @@ pub mod download_session;
 mod eviction;
 pub mod item;
 pub(crate) mod item_read_at;
-pub(crate) mod link_heal;
+pub mod link_heal;
 pub(crate) mod range_db;
 pub(crate) mod worker;
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -8,7 +8,7 @@
 pub mod bitmap;
 #[allow(clippy::module_inception)]
 pub mod cache;
-pub(crate) mod download_session;
+pub mod download_session;
 mod eviction;
 pub mod item;
 pub(crate) mod item_read_at;

--- a/src/cache/worker.rs
+++ b/src/cache/worker.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::{self, Duration};
+use tokio_util::sync::CancellationToken;
 
 /// If no bytes are written to cache for this duration, cancel the in-flight
 /// HTTP stream attempt and retry from the same offset.
@@ -48,6 +49,7 @@ pub(crate) struct DownloaderArgs {
     pub link_refresh_lock: Arc<Mutex<()>>,
     pub heal_remaining: Arc<AtomicU32>,
     pub pause_rx: tokio::sync::watch::Receiver<bool>,
+    pub cancel: CancellationToken,
 }
 
 /// HTTP Range GET pool for `[start, file_end)` using concurrent connection chunking
@@ -66,6 +68,7 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
         link_refresh_lock,
         heal_remaining,
         pause_rx,
+        cancel,
     } = args;
 
     // Apply read-ahead: download further than strictly needed.
@@ -109,12 +112,19 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
         let item_clone = Arc::clone(item);
         let mut p_rx = pause_rx.clone();
         let mult = Arc::clone(&shared_multiplier);
+        let cancel = cancel.clone();
 
         join_set.spawn(async move {
 
             loop {
+                if cancel.is_cancelled() {
+                    break Ok::<(), anyhow::Error>(());
+                }
                 if *p_rx.borrow() {
-                    let _ = p_rx.changed().await;
+                    tokio::select! {
+                        _ = cancel.cancelled() => break Ok::<(), anyhow::Error>(()),
+                        _ = p_rx.changed() => {}
+                    }
                 }
 
                 let chunk_opt = {
@@ -136,9 +146,16 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                 let mut retries = 0;
 
                 loop {
+                    if cancel.is_cancelled() {
+                        return Ok::<(), anyhow::Error>(());
+                    }
                     // Acquire global RD semaphore permit!
-                    let _permit = rd_clone.connection_semaphore.acquire().await
-                        .map_err(|e| anyhow::anyhow!("Semaphore closed: {}", e))?;
+                    let _permit = tokio::select! {
+                        _ = cancel.cancelled() => return Ok::<(), anyhow::Error>(()),
+                        p = rd_clone.connection_semaphore.acquire() => {
+                            p.map_err(|e| anyhow::anyhow!("Semaphore closed: {}", e))?
+                        }
+                    };
 
                     let range_header = format!("bytes={}-{}", chunk_start, chunk_end - 1);
 
@@ -146,12 +163,16 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                     let last_progress = Arc::new(AtomicU64::new(elapsed_nanos()));
                     let lp_clone = Arc::clone(&last_progress);
                     let (watchdog_tx, mut watchdog_rx) = tokio::sync::oneshot::channel::<()>();
+                    let cancel_watchdog = cancel.clone();
 
                     let watchdog = tokio::spawn(async move {
                         let mut interval = time::interval(NO_PROGRESS_CHECK);
                         let timeout_nanos = NO_PROGRESS_TIMEOUT.as_nanos() as u64;
                         loop {
                             interval.tick().await;
+                            if cancel_watchdog.is_cancelled() {
+                                return;
+                            }
                             if watchdog_tx.is_closed() { return; }
                             let last = lp_clone.load(Ordering::Acquire);
                             let now = elapsed_nanos();
@@ -242,6 +263,10 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                             }
                             continue;
                         }
+                        _ = cancel.cancelled() => {
+                            watchdog.abort();
+                            return Ok::<(), anyhow::Error>(());
+                        }
                     };
 
                     let mut chunk_bytes_downloaded = 0u64;
@@ -257,6 +282,10 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                                     "stream body stalled for {secs}s"
                                 ));
                                 break;
+                            }
+                            _ = cancel.cancelled() => {
+                                watchdog.abort();
+                                return Ok::<(), anyhow::Error>(());
                             }
                         };
 
@@ -317,7 +346,10 @@ pub(crate) async fn run_downloader(item: &Arc<CacheItem>, args: DownloaderArgs) 
                                 queue_clone.lock().push_front((new_chunk_end, chunk_end));
                                 chunk_end = new_chunk_end;
                             }
-                            time::sleep(Duration::from_secs(retries as u64 * 2)).await;
+                            tokio::select! {
+                                _ = cancel.cancelled() => return Ok::<(), anyhow::Error>(()),
+                                _ = time::sleep(Duration::from_secs(retries as u64 * 2)) => {}
+                            }
                         }
                     }
                 } // End retry loop

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -44,6 +44,9 @@ pub(super) fn default_bandwidth_reset_timezone() -> String {
 pub(super) fn default_unrestrict_cache_sweep_interval_mins() -> u64 {
     60
 }
+pub(super) fn default_traffic_details_refresh_secs() -> u64 {
+    300
+}
 pub(super) fn default_retries() -> u32 {
     2
 }

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -34,6 +34,18 @@ impl Config {
         if self.api.timeout_secs == 0 {
             bail!("config: api.timeout_secs must be > 0");
         }
+        if self.api.cdn_mode == super::structs::CdnMode::ForceLocation {
+            let loc_ok = self
+                .api
+                .cdn_location
+                .as_ref()
+                .is_some_and(|s| !s.trim().is_empty());
+            if !loc_ok {
+                bail!(
+                    "config: api.cdn_location must be set when api.cdn_mode = \"force_location\""
+                );
+            }
+        }
         Ok(())
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,7 @@ mod defaults;
 mod load;
 mod structs;
 
+pub use structs::CdnMode;
 pub use structs::{ApiConfig, Config, OnLibraryUpdateConfig, RepairConfig, VfsConfig};
 
 /// Parse a human-readable byte-size string (e.g. `"100G"`, `"128M"`, `"4K"`) into bytes.

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -141,6 +141,10 @@ pub struct ApiConfig {
     /// How often to drop in-memory unrestrict cache entries past the 4h TTL. 0 = disabled.
     #[serde(default = "defaults::default_unrestrict_cache_sweep_interval_mins")]
     pub unrestrict_cache_sweep_interval_mins: u64,
+
+    /// Poll `GET /traffic/details` for every download token this often (seconds). Default 300 (5m, zurg-style). 0 = disabled.
+    #[serde(default = "defaults::default_traffic_details_refresh_secs")]
+    pub traffic_details_refresh_secs: u64,
 }
 
 impl Default for ApiConfig {
@@ -159,6 +163,7 @@ impl Default for ApiConfig {
             download_read_timeout_secs: 300,
             bandwidth_reset_timezone: defaults::default_bandwidth_reset_timezone(),
             unrestrict_cache_sweep_interval_mins: 60,
+            traffic_details_refresh_secs: 300,
         }
     }
 }

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -130,6 +130,15 @@ pub struct ApiConfig {
     #[serde(default = "defaults::default_cdn_reprobe_interval_mins")]
     pub cdn_reprobe_interval_mins: u64,
 
+    /// Controls how we shape CDN download URLs (zurg-style).
+    #[serde(default)]
+    pub cdn_mode: CdnMode,
+
+    /// Location/region code for `cdn_mode = "force_location"` (e.g. `"mum"`, `"lax"`, `"syd"`).
+    /// Ignored for other modes.
+    #[serde(default)]
+    pub cdn_location: Option<String>,
+
     /// Max time for a single CDN Range GET (including reading the response body for that chunk). Separate from `timeout_secs` used for API calls.
     #[serde(default = "defaults::default_download_read_timeout_secs")]
     pub download_read_timeout_secs: u64,
@@ -160,12 +169,28 @@ impl Default for ApiConfig {
             use_range_verification: false,
             retain_non_rd_downloads: false,
             cdn_reprobe_interval_mins: 0,
+            cdn_mode: CdnMode::Auto,
+            cdn_location: None,
             download_read_timeout_secs: 300,
             bandwidth_reset_timezone: defaults::default_bandwidth_reset_timezone(),
             unrestrict_cache_sweep_interval_mins: 60,
             traffic_details_refresh_secs: 300,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Default, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CdnMode {
+    /// Default behavior: keep geo-prefixed hosts if RD assigned them; otherwise pin to fastest.
+    #[default]
+    Auto,
+    /// Rewrite CDN host to `.download.real-debrid.cloud` (Cloudflare) variant.
+    ForceCloudflare,
+    /// Ensure we use a numbered host (e.g. `53.download.real-debrid.com`) chosen from reachable set.
+    ForceNumbered,
+    /// Force a location prefix by rewriting to a reachable host matching `cdn_location`.
+    ForceLocation,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/fuse/fs.rs
+++ b/src/fuse/fs.rs
@@ -30,11 +30,13 @@ use bytes::Bytes;
 use dashmap::DashMap;
 use fuse3::raw::prelude::*;
 use fuse3::{Errno, Result as FuseResult};
+use tokio_util::sync::CancellationToken;
 
 use crate::cache::Cache;
 use crate::config::Config;
 use crate::fuse::consts::{INODE_ALL, INODE_FILE_BASE, INODE_ROOT, INODE_TORRENT_BASE};
-use crate::fuse::vfs_read_buffer::VfsReadBuffer;
+use crate::fuse::open_file::OpenFileState;
+use crate::fuse::read_cancel_bridge::FuseReadCancelRegistration;
 use crate::rd::RealDebrid;
 use crate::rd::api::UnrestrictCache;
 use crate::torrent::{ManagedTorrent, TorrentManager};
@@ -60,7 +62,9 @@ pub struct RdFs {
     /// Next FUSE file handle for regular files (`>= 1`; `0` = no per-fd buffer).
     pub(crate) next_fh: AtomicU64,
     /// Per-`fh` read-ahead buffer for file opens (see `vfs_read_buffer`).
-    pub(crate) open_files: DashMap<u64, Arc<tokio::sync::Mutex<VfsReadBuffer>>>,
+    pub(crate) open_files: DashMap<u64, Arc<OpenFileState>>,
+    /// In-flight `read` requests by FUSE `unique` (for [`Filesystem::interrupt`] / Ctrl+C).
+    pub(crate) pending_fuse_reads: Arc<DashMap<u64, CancellationToken>>,
     /// Kernel attribute cache TTL (from `vfs.attr_timeout_secs`).
     pub(crate) attr_ttl: Duration,
     /// Kernel directory-entry cache TTL (from `vfs.entry_timeout_secs`).
@@ -94,6 +98,7 @@ impl RdFs {
             broken_read_warn_ts: DashMap::new(),
             next_fh: AtomicU64::new(1),
             open_files: DashMap::new(),
+            pending_fuse_reads: Arc::new(DashMap::new()),
             attr_ttl: Duration::from_secs(vfs.attr_timeout_secs),
             entry_ttl: Duration::from_secs(vfs.entry_timeout_secs),
         }
@@ -203,10 +208,7 @@ impl Filesystem for RdFs {
             let fh = self
                 .next_fh
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            self.open_files.insert(
-                fh,
-                Arc::new(tokio::sync::Mutex::new(VfsReadBuffer::default())),
-            );
+            self.open_files.insert(fh, Arc::new(OpenFileState::new()));
             return Ok(ReplyOpen { fh, flags: 0 });
         }
         Ok(ReplyOpen { fh: 0, flags: 0 })
@@ -221,7 +223,9 @@ impl Filesystem for RdFs {
         _lock_owner: u64,
         _flush: bool,
     ) -> FuseResult<()> {
-        self.open_files.remove(&fh);
+        if let Some((_, st)) = self.open_files.remove(&fh) {
+            st.cancel();
+        }
         Ok(())
     }
 
@@ -235,15 +239,34 @@ impl Filesystem for RdFs {
         Ok(())
     }
 
+    async fn interrupt(&self, _req: Request, unique: u64) -> FuseResult<()> {
+        if let Some((_, t)) = self.pending_fuse_reads.remove(&unique) {
+            t.cancel();
+            tracing::info!(unique, "fuse interrupt: cancelled in-flight read");
+        }
+        Ok(())
+    }
+
     async fn read(
         &self,
-        _req: Request,
+        req: Request,
         inode: u64,
         fh: u64,
         offset: u64,
         size: u32,
     ) -> FuseResult<ReplyData> {
-        let ctx = tokio_util::sync::CancellationToken::new();
+        let fh_token = self
+            .open_files
+            .get(&fh)
+            .map(|e| e.value().cancel_token())
+            .unwrap_or_default();
+
+        let _read_cancel = FuseReadCancelRegistration::new(
+            req.unique,
+            fh_token,
+            Arc::clone(&self.pending_fuse_reads),
+        );
+        let ctx = _read_cancel.token();
         super::read::read(self, inode, fh, offset, size, &self.unrestrict_cache, ctx).await
     }
 }

--- a/src/fuse/mod.rs
+++ b/src/fuse/mod.rs
@@ -20,8 +20,12 @@ mod fs_helpers;
 mod fs_lookup;
 mod fs_readdir;
 mod fs_readdirplus;
+pub mod open_file;
 pub(crate) mod read;
+mod read_cancel_bridge;
 pub mod vfs_read_buffer;
+
+pub use read_cancel_bridge::FuseReadCancelRegistration;
 
 pub use consts::{INODE_ALL, INODE_FILE_BASE, INODE_ROOT, INODE_TORRENT_BASE};
 pub use fs::RdFs;

--- a/src/fuse/open_file.rs
+++ b/src/fuse/open_file.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use super::vfs_read_buffer::VfsReadBuffer;
+
+/// Per-FUSE-file-handle state: read buffer + cancellation.
+///
+/// Cancellation is tied to the kernel file-handle lifecycle (`release`) and to
+/// each in-flight `read` via [`super::FuseReadCancelRegistration`] (FUSE
+/// `interrupt` when the client aborts a blocked read, e.g. Ctrl+C).
+pub struct OpenFileState {
+    pub buffer: Arc<tokio::sync::Mutex<VfsReadBuffer>>,
+    cancel: CancellationToken,
+}
+
+impl Default for OpenFileState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OpenFileState {
+    pub fn new() -> Self {
+        Self {
+            buffer: Arc::new(tokio::sync::Mutex::new(VfsReadBuffer::default())),
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+}

--- a/src/fuse/read.rs
+++ b/src/fuse/read.rs
@@ -141,7 +141,7 @@ pub async fn read(
         if fh != 0
             && let Some(ent) = fs.open_files.get(&fh)
         {
-            let buf = std::sync::Arc::clone(ent.value());
+            let buf = std::sync::Arc::clone(&ent.value().buffer);
             drop(ent);
             let (fill_offset, fill_len, take) = {
                 let mut g = buf.lock().await;

--- a/src/fuse/read_cancel_bridge.rs
+++ b/src/fuse/read_cancel_bridge.rs
@@ -1,0 +1,52 @@
+//! Bridge per-FUSE-request cancellation: **file handle** (`release`) vs **single syscall** (FUSE
+//! [`interrupt`](https://libfuse.github.io/doxygen/structfuse__lowlevel__ops.html)).
+//!
+//! Ctrl+C on a blocked `read()` typically sends `interrupt` before `release`; without handling it,
+//! background downloads keep running until the fd is closed.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Registers `unique` → cancel token, links cancellation to `fh_token`, and cleans up on drop.
+pub struct FuseReadCancelRegistration {
+    unique: u64,
+    pending: Arc<DashMap<u64, CancellationToken>>,
+    fh_link: JoinHandle<()>,
+    token: CancellationToken,
+}
+
+impl FuseReadCancelRegistration {
+    pub fn new(
+        unique: u64,
+        fh_token: CancellationToken,
+        pending: Arc<DashMap<u64, CancellationToken>>,
+    ) -> Self {
+        let token = CancellationToken::new();
+        pending.insert(unique, token.clone());
+        let token_fh = token.clone();
+        let fh_link = tokio::spawn(async move {
+            fh_token.cancelled().await;
+            token_fh.cancel();
+        });
+        Self {
+            unique,
+            pending,
+            fh_link,
+            token,
+        }
+    }
+
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+}
+
+impl Drop for FuseReadCancelRegistration {
+    fn drop(&mut self) {
+        self.fh_link.abort();
+        self.pending.remove(&self.unique);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,7 @@ async fn run_fuse_mount() -> Result<()> {
             loop {
                 let tz = config_bw.load().api.bandwidth_reset_timezone.clone();
                 let sleep_dur = rd_rs::rd::bandwidth_reset::duration_until_timezone_midnight(&tz);
+                // TODO: if the server is offline or suspended exactly during local midnight, they may skip resetting the tokens for that 24h block until a hot reboot.
                 tokio::time::sleep(sleep_dur).await;
                 rd_bw.token_pool.clear_all_exhausted();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,22 @@ async fn run_fuse_mount() -> Result<()> {
         });
     }
 
+    {
+        let rd_td = rd_client.clone();
+        let config_td = config.clone();
+        tokio::spawn(async move {
+            loop {
+                let secs = config_td.load().api.traffic_details_refresh_secs;
+                if secs == 0 {
+                    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                    continue;
+                }
+                rd_td.refresh_traffic_details_snapshot().await;
+                tokio::time::sleep(std::time::Duration::from_secs(secs.max(1))).await;
+            }
+        });
+    }
+
     let mut mount_options = fuse3::MountOptions::default();
     mount_options
         .allow_other(true)

--- a/src/rd/api/methods2.rs
+++ b/src/rd/api/methods2.rs
@@ -19,7 +19,15 @@ impl RealDebrid {
         link: &str,
     ) -> Result<Download, RdError> {
         let link_arc = Arc::new(link.to_string());
-        let form_body = format!("link={}", urlencoding_encode(link));
+        let mut form_body = format!("link={}", urlencoding_encode(link));
+        if self.config.api.cdn_mode == crate::config::CdnMode::ForceLocation
+            && let Some(loc) = self.config.api.cdn_location.as_deref()
+            && let Some(pin) = &*self.ranked_hosts.load()
+            && let Some(ip) = pin.geo_unrestrict_ip(loc, link)
+        {
+            form_body.push_str("&ip=");
+            form_body.push_str(&urlencoding_encode(&ip));
+        }
         let url = format!(
             "{}/rest/1.0/unrestrict/link",
             self.config.api.base_url.trim_end_matches('/')

--- a/src/rd/api/methods3.rs
+++ b/src/rd/api/methods3.rs
@@ -30,7 +30,11 @@ impl RealDebrid {
     /// Returns `Some(String)` if the URL was rewritten, otherwise `None` (use the original URL).
     pub(crate) fn rewrite_download_url(&self, url: &str, use_fallback: bool) -> Option<String> {
         if !use_fallback && let Some(pin) = &*self.ranked_hosts.load() {
-            pin.rewrite_url(url)
+            pin.rewrite_url(
+                url,
+                self.config.api.cdn_mode,
+                self.config.api.cdn_location.as_deref(),
+            )
         } else {
             None
         }

--- a/src/rd/cdn/host_map.rs
+++ b/src/rd/cdn/host_map.rs
@@ -1,10 +1,15 @@
 use reqwest::Url;
+use std::collections::HashMap;
 use std::sync::Arc;
+
+use crate::config::CdnMode;
 
 /// In-memory holder for the fastest CDN host.
 #[derive(Debug, Clone)]
 pub struct RankedHosts {
     pub fastest_host: String,
+    pub reachable_ipv4_hosts: Arc<Vec<String>>,
+    pub ipv4_addresses: Arc<HashMap<String, String>>,
 }
 
 impl RankedHosts {
@@ -24,6 +29,8 @@ impl RankedHosts {
 
         Some(Arc::new(Self {
             fastest_host: fastest.clone(),
+            reachable_ipv4_hosts: Arc::new(results.ipv4_addresses.keys().cloned().collect()),
+            ipv4_addresses: Arc::new(results.ipv4_addresses),
         }))
     }
 
@@ -31,25 +38,118 @@ impl RankedHosts {
     /// Retains the original path and scheme.
     /// Returns None if it's not a real-debrid CDN URL, parsing fails,
     /// or the URL is **already** on the pinned host (no-op rewrite avoided).
-    pub fn rewrite_url(&self, download_url: &str) -> Option<String> {
+    pub fn rewrite_url(
+        &self,
+        download_url: &str,
+        mode: CdnMode,
+        location: Option<&str>,
+    ) -> Option<String> {
         let mut parsed = Url::parse(download_url).ok()?;
 
         let host = parsed.host_str()?;
-        if host.ends_with(".download.real-debrid.com")
-            || host.ends_with(".download.real-debrid.net")
-        {
-            // Skip rewrite if already on the pinned host — the fallback path
-            // in exec.rs uses the original URL when use_fallback=true, so a
-            // no-op rewrite would make the "pinned" and "fallback" requests
-            // identical, wasting a retry on the same dead host.
-            if host == self.fastest_host {
-                return None;
-            }
-            // Un-pinned URL -> Pinned URL
-            parsed.set_host(Some(&self.fastest_host)).ok()?;
-            return Some(parsed.to_string());
+        if !is_rd_cdn_host(host) {
+            return None;
         }
 
-        None
+        let target_host: String = match mode {
+            CdnMode::Auto => {
+                // Preserve letter-prefixed geo hosts (zurg-style).
+                if is_geo_prefixed(host) {
+                    return None;
+                }
+                self.fastest_host.clone()
+            }
+            CdnMode::ForceCloudflare => return rewrite_to_cloudflare(&parsed),
+            CdnMode::ForceNumbered => pick_numbered_host(host, &self.reachable_ipv4_hosts)?,
+            CdnMode::ForceLocation => {
+                let loc = location?;
+                pick_location_host(host, loc, &self.reachable_ipv4_hosts)?
+            }
+        };
+
+        // Skip rewrite if already on the chosen host — avoids wasting a fallback retry.
+        if host == target_host {
+            return None;
+        }
+
+        parsed.set_host(Some(&target_host)).ok()?;
+        Some(parsed.to_string())
     }
+
+    /// Returns a verified IPv4 address that matches `loc` (used for geo-aware unrestrict).
+    pub fn geo_unrestrict_ip(&self, loc: &str, seed: &str) -> Option<String> {
+        let host = pick_location_host(seed, loc, &self.reachable_ipv4_hosts)?;
+        self.ipv4_addresses.get(&host).cloned()
+    }
+}
+
+fn is_rd_cdn_host(host: &str) -> bool {
+    host.ends_with(".download.real-debrid.com")
+        || host.ends_with(".download.real-debrid.net")
+        || host.ends_with(".download.real-debrid.cloud")
+}
+
+fn is_geo_prefixed(host: &str) -> bool {
+    // e.g. "lax2-4.download.real-debrid.com" / "mum1-4.download.real-debrid.com"
+    let prefix = host.split('.').next().unwrap_or(host);
+    prefix
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+        && prefix.contains('-')
+}
+
+fn is_numbered_prefix(prefix: &str) -> bool {
+    !prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_digit())
+}
+
+fn pick_numbered_host(current_host: &str, reachable: &[String]) -> Option<String> {
+    let current_prefix = current_host.split('.').next().unwrap_or(current_host);
+    if is_numbered_prefix(current_prefix) && reachable.iter().any(|h| h == current_host) {
+        return Some(current_host.to_string());
+    }
+
+    // Deterministic “random”: hash the current host, then mod into candidates.
+    let candidates: Vec<String> = reachable
+        .iter()
+        .map(|h| h.to_string())
+        .filter(|h| is_numbered_prefix(h.split('.').next().unwrap_or(h)))
+        .collect();
+    pick_deterministic(current_host, &candidates)
+}
+
+fn pick_location_host(current_host: &str, loc: &str, reachable: &[String]) -> Option<String> {
+    let loc = loc.trim().to_ascii_lowercase();
+    let candidates: Vec<String> = reachable
+        .iter()
+        .map(|h| h.to_string())
+        .filter(|h| {
+            let prefix = h.split('.').next().unwrap_or(h);
+            prefix.to_ascii_lowercase().starts_with(&loc)
+        })
+        .collect();
+    pick_deterministic(current_host, &candidates)
+}
+
+fn pick_deterministic(seed: &str, candidates: &[String]) -> Option<String> {
+    if candidates.is_empty() {
+        return None;
+    }
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    seed.hash(&mut hasher);
+    let idx = (hasher.finish() as usize) % candidates.len();
+    Some(candidates[idx].clone())
+}
+
+fn rewrite_to_cloudflare(parsed: &Url) -> Option<String> {
+    let mut u = parsed.clone();
+    let host = u.host_str()?;
+    if host.ends_with(".download.real-debrid.cloud") {
+        return None;
+    }
+    let prefix = host.split('.').next().unwrap_or(host);
+    let new_host = format!("{prefix}.download.real-debrid.cloud");
+    u.set_host(Some(&new_host)).ok()?;
+    Some(u.to_string())
 }

--- a/src/rd/mod.rs
+++ b/src/rd/mod.rs
@@ -8,6 +8,7 @@ pub mod bandwidth_reset;
 pub mod cdn;
 pub mod client;
 pub mod token_pool;
+pub mod traffic_snapshot;
 pub mod types;
 
 use std::sync::Arc;
@@ -18,6 +19,7 @@ use arc_swap::ArcSwap;
 use reqwest::ClientBuilder;
 
 use crate::config::Config;
+use crate::rd::types::TrafficDetailsSnapshot;
 use client::{Credentials, RateLimiter, RdClient, RdClientConfig};
 use token_pool::TokenPool;
 
@@ -40,6 +42,8 @@ pub struct RealDebrid {
     pub token_pool: Arc<TokenPool>,
     pub config: Arc<Config>,
     pub ranked_hosts: Arc<arc_swap::ArcSwapOption<cdn::RankedHosts>>,
+    /// Latest per-token `GET /traffic/details` snapshot when refresh is enabled in config.
+    pub traffic_details: Arc<arc_swap::ArcSwapOption<TrafficDetailsSnapshot>>,
     /// Shared, hot-swappable credentials. Updated atomically by [`reload_credentials`](Self::reload_credentials).
     pub credentials: Arc<ArcSwap<Credentials>>,
 }
@@ -148,6 +152,7 @@ impl RealDebrid {
             token_pool,
             config: Arc::new(cfg.clone()),
             ranked_hosts: Arc::new(arc_swap::ArcSwapOption::new(None)),
+            traffic_details: Arc::new(arc_swap::ArcSwapOption::new(None)),
             credentials,
         })
     }

--- a/src/rd/traffic_snapshot.rs
+++ b/src/rd/traffic_snapshot.rs
@@ -1,0 +1,54 @@
+//! Periodic `GET /traffic/details` per download token (zurg-style traffic refresher).
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+
+use super::RealDebrid;
+use crate::rd::types::{TrafficDetailsResponse, TrafficDetailsSnapshot};
+
+impl RealDebrid {
+    /// Fetches `/traffic/details` once per token in the pool and stores the result in
+    /// [`Self::traffic_details`]. Failed tokens are skipped with a warning.
+    pub async fn refresh_traffic_details_snapshot(&self) {
+        let base = self.config.api.base_url.trim_end_matches('/');
+        let url = format!("{base}/rest/1.0/traffic/details");
+        let tokens = self.token_pool.tokens_in_order();
+        let mut by_token = Vec::with_capacity(tokens.len());
+        for token in tokens {
+            match self.fetch_traffic_details_token(token.as_str(), &url).await {
+                Ok(details) => {
+                    tracing::debug!(
+                        days = details.len(),
+                        "traffic/details refreshed for one token slot"
+                    );
+                    by_token.push((token, details));
+                }
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    "traffic/details failed for one token slot; skipping"
+                ),
+            }
+        }
+        self.traffic_details
+            .store(Some(Arc::new(TrafficDetailsSnapshot {
+                fetched_at: Utc::now(),
+                by_token,
+            })));
+    }
+
+    async fn fetch_traffic_details_token(
+        &self,
+        token: &str,
+        url: &str,
+    ) -> Result<TrafficDetailsResponse> {
+        let resp = self
+            .api_client
+            .execute_with_fixed_bearer(token, |_| self.api_client.client.get(url))
+            .await
+            .context("traffic/details HTTP")?;
+        let t: TrafficDetailsResponse = resp.json().await.context("traffic/details decode")?;
+        Ok(t)
+    }
+}

--- a/src/rd/types.rs
+++ b/src/rd/types.rs
@@ -4,6 +4,8 @@
 //! but are actually **Europe/Paris** local time. We parse them accordingly
 //! via `parse_paris_time` and store all times as `DateTime<Utc>`.
 
+use std::sync::Arc;
+
 use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Europe::Paris;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -204,15 +206,26 @@ pub struct ActiveTorrentCountResponse {
 
 // ─── Traffic ──────────────────────────────────────────────────────────────────
 
-/// Response from `GET /rest/1.0/traffic/details`.
-/// It's a map of host -> TrafficHost.
-pub type TrafficDetailsResponse = std::collections::HashMap<String, TrafficHost>;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TrafficHost {
+/// One day bucket in `GET /rest/1.0/traffic/details` (API keys are ISO dates, e.g. `2015-12-09`).
+///
+/// Not to be confused with `GET /rest/1.0/traffic` (host limits); `/details` is usage **by day**.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TrafficDetailDay {
+    /// Per-host byte totals for that day.
+    #[serde(default)]
+    pub host: std::collections::HashMap<String, i64>,
+    #[serde(default)]
     pub bytes: i64,
-    pub links: i64,
-    pub reset: i64,
+}
+
+/// Response from `GET /rest/1.0/traffic/details`: date string → that day’s host breakdown + total bytes.
+pub type TrafficDetailsResponse = std::collections::HashMap<String, TrafficDetailDay>;
+
+/// In-memory snapshot of [`TrafficDetailsResponse`] for each configured download token (primary first).
+#[derive(Debug, Clone)]
+pub struct TrafficDetailsSnapshot {
+    pub fetched_at: DateTime<Utc>,
+    pub by_token: Vec<(Arc<String>, TrafficDetailsResponse)>,
 }
 
 // ─── Downloads ────────────────────────────────────────────────────────────────

--- a/tests/cache_get_or_create_tests.rs
+++ b/tests/cache_get_or_create_tests.rs
@@ -1,0 +1,23 @@
+//! Cache `get_or_create` returns a single shared item per key.
+
+use std::sync::Arc;
+
+use rd_rs::cache::Cache;
+use rd_rs::config::VfsConfig;
+
+#[tokio::test]
+async fn get_or_create_same_arc_per_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let vfs = Arc::new(VfsConfig::default());
+    let cache = Cache::new(dir.path(), vfs);
+    let a = cache
+        .get_or_create("ak", "movie.mkv", 4096)
+        .expect("first create");
+    let b = cache
+        .get_or_create("ak", "movie.mkv", 4096)
+        .expect("second get");
+    assert!(
+        Arc::ptr_eq(&a, &b),
+        "get_or_create must return the same Arc as the live map entry"
+    );
+}

--- a/tests/cdn_host_map_tests.rs
+++ b/tests/cdn_host_map_tests.rs
@@ -1,13 +1,25 @@
 use rd_rs::rd::cdn::RankedHosts;
+use std::sync::Arc;
 
 #[test]
 fn test_rewrite_url_success() {
     let hosts = RankedHosts {
         fastest_host: "mum1-1.download.real-debrid.com".to_string(),
+        reachable_ipv4_hosts: Arc::new(vec![
+            "53.download.real-debrid.com".to_string(),
+            "13.download.real-debrid.com".to_string(),
+            "mum1-1.download.real-debrid.com".to_string(),
+            "lax2-4.download.real-debrid.com".to_string(),
+        ]),
+        ipv4_addresses: Arc::new(Default::default()),
     };
 
     let pined = hosts
-        .rewrite_url("https://53.download.real-debrid.com/d/XYZ/file.mkv")
+        .rewrite_url(
+            "https://53.download.real-debrid.com/d/XYZ/file.mkv",
+            rd_rs::config::CdnMode::Auto,
+            None,
+        )
         .unwrap();
     assert_eq!(
         pined,
@@ -15,7 +27,11 @@ fn test_rewrite_url_success() {
     );
 
     let pined2 = hosts
-        .rewrite_url("https://13.download.real-debrid.net/path?q=1")
+        .rewrite_url(
+            "https://13.download.real-debrid.net/path?q=1",
+            rd_rs::config::CdnMode::Auto,
+            None,
+        )
         .unwrap();
     assert_eq!(pined2, "https://mum1-1.download.real-debrid.com/path?q=1");
 }
@@ -24,11 +40,100 @@ fn test_rewrite_url_success() {
 fn test_rewrite_url_ignores_non_cdn() {
     let hosts = RankedHosts {
         fastest_host: "mum1-1.download.real-debrid.com".to_string(),
+        reachable_ipv4_hosts: Arc::new(vec![]),
+        ipv4_addresses: Arc::new(Default::default()),
     };
 
-    let pined = hosts.rewrite_url("https://api.real-debrid.com/rest/1.0/user");
+    let pined = hosts.rewrite_url(
+        "https://api.real-debrid.com/rest/1.0/user",
+        rd_rs::config::CdnMode::Auto,
+        None,
+    );
     assert_eq!(pined, None);
 
-    let pined2 = hosts.rewrite_url("https://google.com/d/XYZ/file.mkv");
+    let pined2 = hosts.rewrite_url(
+        "https://google.com/d/XYZ/file.mkv",
+        rd_rs::config::CdnMode::Auto,
+        None,
+    );
     assert_eq!(pined2, None);
+}
+
+#[test]
+fn test_auto_preserves_geo_host() {
+    let hosts = RankedHosts {
+        fastest_host: "mum1-1.download.real-debrid.com".to_string(),
+        reachable_ipv4_hosts: Arc::new(vec![
+            "lax2-4.download.real-debrid.com".to_string(),
+            "mum1-1.download.real-debrid.com".to_string(),
+        ]),
+        ipv4_addresses: Arc::new(Default::default()),
+    };
+
+    let keep = hosts.rewrite_url(
+        "https://lax2-4.download.real-debrid.com/d/XYZ/file.mkv",
+        rd_rs::config::CdnMode::Auto,
+        None,
+    );
+    assert_eq!(keep, None);
+}
+
+#[test]
+fn test_force_cloudflare_rewrites_tld() {
+    let hosts = RankedHosts {
+        fastest_host: "mum1-1.download.real-debrid.com".to_string(),
+        reachable_ipv4_hosts: Arc::new(vec![]),
+        ipv4_addresses: Arc::new(Default::default()),
+    };
+    let pinned = hosts
+        .rewrite_url(
+            "https://53.download.real-debrid.com/d/XYZ/file.mkv",
+            rd_rs::config::CdnMode::ForceCloudflare,
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        pinned,
+        "https://53.download.real-debrid.cloud/d/XYZ/file.mkv"
+    );
+}
+
+#[test]
+fn test_force_numbered_picks_numbered_host() {
+    let hosts = RankedHosts {
+        fastest_host: "mum1-1.download.real-debrid.com".to_string(),
+        reachable_ipv4_hosts: Arc::new(vec![
+            "53.download.real-debrid.com".to_string(),
+            "13.download.real-debrid.com".to_string(),
+        ]),
+        ipv4_addresses: Arc::new(Default::default()),
+    };
+    let pinned = hosts
+        .rewrite_url(
+            "https://lax2-4.download.real-debrid.com/d/XYZ/file.mkv",
+            rd_rs::config::CdnMode::ForceNumbered,
+            None,
+        )
+        .unwrap();
+    assert!(
+        pinned.contains("13.download.real-debrid.com")
+            || pinned.contains("53.download.real-debrid.com")
+    );
+}
+
+#[test]
+fn test_force_location_requires_match() {
+    let hosts = RankedHosts {
+        fastest_host: "mum1-1.download.real-debrid.com".to_string(),
+        reachable_ipv4_hosts: Arc::new(vec!["mum2-4.download.real-debrid.com".to_string()]),
+        ipv4_addresses: Arc::new(Default::default()),
+    };
+    let pinned = hosts
+        .rewrite_url(
+            "https://53.download.real-debrid.com/d/XYZ/file.mkv",
+            rd_rs::config::CdnMode::ForceLocation,
+            Some("mum"),
+        )
+        .unwrap();
+    assert!(pinned.contains("mum2-4.download.real-debrid.com"));
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -13,6 +13,7 @@ fn parse_minimal_toml() {
     assert_eq!(cfg.api.download_read_timeout_secs, 300);
     assert_eq!(cfg.api.bandwidth_reset_timezone, "Europe/Paris");
     assert_eq!(cfg.api.unrestrict_cache_sweep_interval_mins, 60);
+    assert_eq!(cfg.api.traffic_details_refresh_secs, 300);
     assert_eq!(cfg.repair.every_mins, 60);
     assert_eq!(cfg.vfs.chunk_size, "4M");
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -10,6 +10,8 @@ fn parse_minimal_toml() {
     assert_eq!(cfg.api.rate_limit_per_minute, 250);
     assert_eq!(cfg.api.refresh_interval_secs, 15);
     assert_eq!(cfg.api.cdn_reprobe_interval_mins, 0);
+    assert_eq!(cfg.api.cdn_mode, rd_rs::config::CdnMode::Auto);
+    assert_eq!(cfg.api.cdn_location, None);
     assert_eq!(cfg.api.download_read_timeout_secs, 300);
     assert_eq!(cfg.api.bandwidth_reset_timezone, "Europe/Paris");
     assert_eq!(cfg.api.unrestrict_cache_sweep_interval_mins, 60);
@@ -37,6 +39,8 @@ fn parse_full_toml() {
         rate_limit_per_minute = 100
         timeout_secs = 30
         refresh_interval_secs = 45
+        cdn_mode = "force_location"
+        cdn_location = "mum"
 
         [vfs]
         chunk_size = "8M"
@@ -47,6 +51,8 @@ fn parse_full_toml() {
     assert_eq!(cfg.repair.every_mins, 30);
     assert_eq!(cfg.api.rate_limit_per_minute, 100);
     assert_eq!(cfg.api.refresh_interval_secs, 45);
+    assert_eq!(cfg.api.cdn_mode, rd_rs::config::CdnMode::ForceLocation);
+    assert_eq!(cfg.api.cdn_location.as_deref(), Some("mum"));
     assert_eq!(cfg.vfs.chunk_size, "8M");
     assert_eq!(cfg.vfs.max_parallel_streams, 4);
 }
@@ -54,6 +60,16 @@ fn parse_full_toml() {
 #[test]
 fn empty_token_fails_validation() {
     let toml = r#"token = """#;
+    assert!(Config::from_toml(toml).is_err());
+}
+
+#[test]
+fn force_location_requires_location() {
+    let toml = r#"
+        token = "ABC"
+        [api]
+        cdn_mode = "force_location"
+    "#;
     assert!(Config::from_toml(toml).is_err());
 }
 

--- a/tests/fuse_read_cancel_bridge_tests.rs
+++ b/tests/fuse_read_cancel_bridge_tests.rs
@@ -1,0 +1,35 @@
+//! `FuseReadCancelRegistration` — per-request cancel + fh propagation.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use rd_rs::fuse::FuseReadCancelRegistration;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn interrupt_removes_pending_and_cancels_token() {
+    let pending = Arc::new(DashMap::new());
+    let fh = CancellationToken::new();
+    let reg = FuseReadCancelRegistration::new(7, fh.clone(), Arc::clone(&pending));
+    let t = reg.token();
+    assert!(pending.contains_key(&7));
+
+    let removed = pending.remove(&7).expect("entry");
+    removed.1.cancel();
+    tokio::time::timeout(Duration::from_secs(2), t.cancelled())
+        .await
+        .expect("timeout");
+}
+
+#[tokio::test]
+async fn fh_cancel_propagates_to_read_token() {
+    let pending = Arc::new(DashMap::new());
+    let fh = CancellationToken::new();
+    let reg = FuseReadCancelRegistration::new(1, fh.clone(), Arc::clone(&pending));
+    let t = reg.token();
+    fh.cancel();
+    tokio::time::timeout(Duration::from_secs(2), t.cancelled())
+        .await
+        .expect("timeout");
+}

--- a/tests/geo_unrestrict_ip_tests.rs
+++ b/tests/geo_unrestrict_ip_tests.rs
@@ -1,0 +1,92 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use mockito::Matcher;
+use mockito::Server;
+use rd_rs::config::Config;
+use rd_rs::rd::cdn::RankedHosts;
+use rd_rs::rd::{RealDebrid, api::new_unrestrict_cache};
+
+#[tokio::test]
+async fn unrestrict_includes_ip_when_force_location_enabled() {
+    let mut server = Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/rest/1.0/unrestrict/link")
+        .match_header("content-type", "application/x-www-form-urlencoded")
+        .match_body(Matcher::Regex("link=".into()))
+        .match_body(Matcher::Regex("ip=203\\.0\\.113\\.10".into()))
+        .with_status(200)
+        .with_body(
+            r#"{"filename":"f.mkv","filesize":1,"link":"L","download":"https://53.download.real-debrid.com/d/XYZ/file.mkv","streamable":1}"#,
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let json = r#"{
+        "token": "dummy",
+        "mount_path": "/tmp/rd-rs-mount",
+        "cache_dir": "/tmp/rd-rs-cache",
+        "api": { "cdn_mode": "force_location", "cdn_location": "mum" }
+    }"#;
+    let mut cfg: Config = serde_json::from_str(json).unwrap();
+    cfg.api.base_url = server.url();
+
+    let rd = Arc::new(RealDebrid::new(&cfg).unwrap());
+
+    let mut ips = HashMap::new();
+    ips.insert(
+        "mum2-4.download.real-debrid.com".to_string(),
+        "203.0.113.10".to_string(),
+    );
+    let hosts = RankedHosts {
+        fastest_host: "mum2-4.download.real-debrid.com".to_string(),
+        reachable_ipv4_hosts: Arc::new(vec!["mum2-4.download.real-debrid.com".to_string()]),
+        ipv4_addresses: Arc::new(ips),
+    };
+    rd.ranked_hosts.store(Some(Arc::new(hosts)));
+
+    let cache = new_unrestrict_cache();
+    let _ = rd
+        .unrestrict_link(&cache, "https://example.com/source")
+        .await
+        .unwrap();
+
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn unrestrict_does_not_require_ip_when_not_force_location() {
+    let mut server = Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/rest/1.0/unrestrict/link")
+        .match_header("content-type", "application/x-www-form-urlencoded")
+        .match_body(Matcher::Exact("link=https://example.com/source".into()))
+        .with_status(200)
+        .with_body(
+            r#"{"filename":"f.mkv","filesize":1,"link":"L","download":"https://53.download.real-debrid.com/d/XYZ/file.mkv","streamable":1}"#,
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let json = r#"{
+        "token": "dummy",
+        "mount_path": "/tmp/rd-rs-mount",
+        "cache_dir": "/tmp/rd-rs-cache",
+        "api": { "cdn_mode": "auto" }
+    }"#;
+    let mut cfg: Config = serde_json::from_str(json).unwrap();
+    cfg.api.base_url = server.url();
+
+    let rd = Arc::new(RealDebrid::new(&cfg).unwrap());
+    let cache = new_unrestrict_cache();
+    let _ = rd
+        .unrestrict_link(&cache, "https://example.com/source")
+        .await
+        .unwrap();
+
+    mock.assert_async().await;
+}

--- a/tests/link_heal_cache_clear_tests.rs
+++ b/tests/link_heal_cache_clear_tests.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use mockito::Matcher;
+use mockito::Server;
+use rd_rs::rd::api::UnrestrictCacheKey;
+use rd_rs::rd::{RealDebrid, api::new_unrestrict_cache};
+use tokio::sync::{Mutex, RwLock};
+
+#[tokio::test]
+async fn link_heal_clears_all_token_buckets_for_source_link() {
+    use rd_rs::cache::link_heal::{MAX_SESSION_LINK_HEALS, attempt_cdn_link_refresh};
+    use rd_rs::rd::client::{DownloadError, RdError};
+    use std::sync::atomic::AtomicU32;
+
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/rest/1.0/unrestrict/link")
+        .match_header("content-type", "application/x-www-form-urlencoded")
+        .match_body(Matcher::Regex("link=".into()))
+        .with_status(200)
+        .with_body(
+            r#"{"filename":"f.mkv","filesize":1,"link":"L","download":"https://53.download.real-debrid.com/d/XYZ/file.mkv","streamable":1}"#,
+        )
+        .expect(1)
+        .create_async()
+        .await;
+
+    let json = r#"{
+        "token": "T0",
+        "download_tokens": ["T1"],
+        "mount_path": "/tmp/rd-rs-mount",
+        "cache_dir": "/tmp/rd-rs-cache",
+        "api": { "base_url": "http://127.0.0.1" }
+    }"#;
+    let mut cfg: rd_rs::config::Config = serde_json::from_str(json).unwrap();
+    cfg.api.base_url = server.url();
+    let rd = Arc::new(RealDebrid::new(&cfg).unwrap());
+
+    let cache = new_unrestrict_cache();
+    let source_link = "https://example.com/source";
+
+    // Pre-seed cache in two token buckets to simulate multi-token stale entries.
+    cache.insert(
+        UnrestrictCacheKey::new(
+            Arc::new("T0".to_string()),
+            Arc::new(source_link.to_string()),
+        ),
+        (
+            rd_rs::rd::types::Download {
+                download: "https://old0/d/X".into(),
+                token: "T0".into(),
+                ..Default::default()
+            },
+            tokio::time::Instant::now(),
+        ),
+    );
+    cache.insert(
+        UnrestrictCacheKey::new(
+            Arc::new("T1".to_string()),
+            Arc::new(source_link.to_string()),
+        ),
+        (
+            rd_rs::rd::types::Download {
+                download: "https://old1/d/X".into(),
+                token: "T1".into(),
+                ..Default::default()
+            },
+            tokio::time::Instant::now(),
+        ),
+    );
+
+    let live = RwLock::new("https://old/d/X".to_string());
+    let refresh_lock = Mutex::new(());
+    let heal_remaining = AtomicU32::new(MAX_SESSION_LINK_HEALS);
+
+    // Any error that triggers refresh via unrestrict.
+    let err = RdError::Download(DownloadError::InvalidDownloadCode);
+
+    let did = attempt_cdn_link_refresh(
+        &err,
+        &rd,
+        &cache,
+        source_link,
+        &live,
+        &refresh_lock,
+        &heal_remaining,
+    )
+    .await;
+    assert!(did);
+
+    // Both buckets must be cleared before re-unrestricting; after refresh, exactly one fresh entry remains.
+    assert_eq!(cache.len(), 1);
+
+    mock.assert_async().await;
+}

--- a/tests/open_file_state_tests.rs
+++ b/tests/open_file_state_tests.rs
@@ -1,0 +1,10 @@
+use rd_rs::fuse::open_file::OpenFileState;
+
+#[test]
+fn open_file_state_cancels_token() {
+    let st = OpenFileState::new();
+    let tok = st.cancel_token();
+    assert!(!tok.is_cancelled());
+    st.cancel();
+    assert!(tok.is_cancelled());
+}

--- a/tests/read_cancel_tests.rs
+++ b/tests/read_cancel_tests.rs
@@ -1,0 +1,25 @@
+//! Cancellation propagation: last waiter aborts download session promptly.
+
+use std::time::Duration;
+
+use rd_rs::cache::download_session::{DownloadSession, WaiterGuard};
+
+#[tokio::test]
+async fn last_waiter_aborts_session_task() {
+    let session = std::sync::Arc::new(DownloadSession::new(0, 1024));
+    let handle = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    });
+    session.set_abort_handle(handle.abort_handle());
+
+    {
+        let _w = WaiterGuard::new(session);
+        // Drop _w at end of scope: last waiter → cancel + abort.
+    }
+
+    let res = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    assert!(
+        res.is_ok(),
+        "session task should abort quickly after last waiter drops"
+    );
+}

--- a/tests/traffic_details_tests.rs
+++ b/tests/traffic_details_tests.rs
@@ -1,0 +1,40 @@
+//! Tests for traffic / bandwidth JSON types.
+
+use rd_rs::rd::types::{TrafficDetailDay, TrafficDetailsResponse};
+
+#[test]
+fn deserialize_traffic_details_per_day_shape() {
+    let json = r#"{
+        "2015-12-09": {
+            "host": { "uptobox.com": 11066701819 },
+            "bytes": 11066701819
+        },
+        "2015-12-08": {
+            "host": { "uptobox.com": 872664221 },
+            "bytes": 872664221
+        }
+    }"#;
+    let m: TrafficDetailsResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(m.len(), 2);
+    let d = m.get("2015-12-09").unwrap();
+    assert_eq!(d.bytes, 11066701819);
+    assert_eq!(d.host.get("uptobox.com").copied(), Some(11066701819));
+}
+
+#[test]
+fn traffic_detail_day_roundtrip() {
+    let d = TrafficDetailDay {
+        host: [("x.com".into(), 42)].into_iter().collect(),
+        bytes: 42,
+    };
+    let s = serde_json::to_string(&d).unwrap();
+    let back: TrafficDetailDay = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.bytes, d.bytes);
+    assert_eq!(back.host.get("x.com").copied(), Some(42));
+}
+
+#[test]
+fn deserialize_empty_traffic_details_object() {
+    let m: TrafficDetailsResponse = serde_json::from_str("{}").unwrap();
+    assert!(m.is_empty());
+}


### PR DESCRIPTION
This is part 9 of 11 in the cumulative PR chain. 

Current PR contains all architectural changes from part 1 up to 9 against `main`.