### PR TITLE
Part 10/11: fix(cache): prevent eviction race during get_or_create

### DIFF
--- a/src/cache/cache.rs
+++ b/src/cache/cache.rs
@@ -91,8 +91,8 @@ impl Cache {
     ) -> anyhow::Result<Arc<CacheItem>> {
         let key = Self::build_key(access_key, filename);
 
-        match self.items.entry(key.clone()) {
-            Entry::Occupied(o) => Ok(Arc::clone(o.get())),
+        let item = match self.items.entry(key.clone()) {
+            Entry::Occupied(o) => Arc::clone(o.get()),
             Entry::Vacant(v) => {
                 let path = self.cache_dir.join(access_key).join(filename);
                 let item = CacheItem::open_or_create_with_db(
@@ -103,9 +103,14 @@ impl Cache {
                 )?;
                 tracing::info!(file = %filename, key = %key, "cache open");
                 let r = v.insert(item);
-                Ok(Arc::clone(r.value()))
+                Arc::clone(r.value())
             }
-        }
+        };
+
+        // Mark open *before* returning so the eviction loop cannot remove this key while a caller
+        // is in-flight between get_or_create() and CacheItem::open().
+        item.open();
+        Ok(item)
     }
 
     /// Drop in-memory entry, remove the sparse file, and delete persisted range metadata.
@@ -160,6 +165,11 @@ impl Cache {
             interval.tick().await;
             super::eviction::evict(self);
         }
+    }
+
+    /// Run one eviction pass immediately (useful for tests / ops).
+    pub fn evict_once(&self) {
+        super::eviction::evict(self);
     }
 
     pub fn evict_disk_lru(&self, threshold: u64, now_secs: u64) {

--- a/src/cache/eviction.rs
+++ b/src/cache/eviction.rs
@@ -34,6 +34,12 @@ pub(super) fn evict(cache: &Cache) {
 
     for key in &to_remove {
         if let Some((_, item)) = cache.items.remove(key) {
+            // Avoid removing entries that were concurrently acquired and opened after we built
+            // `to_remove` (open() happens in get_or_create()).
+            if item.is_open() {
+                cache.items.insert(key.clone(), item);
+                continue;
+            }
             item.flush_ranges(true);
         }
     }

--- a/src/cache/item.rs
+++ b/src/cache/item.rs
@@ -158,6 +158,11 @@ impl CacheItem {
         self.atime.load(Ordering::Relaxed)
     }
 
+    /// Force-set atime (seconds since epoch). Intended for tests/diagnostics.
+    pub fn set_atime_secs(&self, secs: u64) {
+        self.atime.store(secs, Ordering::Relaxed);
+    }
+
     /// Returns `true` if `[start, end)` is fully in the on-disk cache.
     pub fn has_range(&self, start: u64, end: u64) -> bool {
         self.ranges.read().has_range(start, end)

--- a/src/fuse/read.rs
+++ b/src/fuse/read.rs
@@ -116,7 +116,6 @@ pub async fn read(
             Errno::from(libc::EIO)
         })?;
 
-    cache_item.open();
     // Decrement on exit (regardless of success/failure path).
     struct ReleaseGuard<'a>(&'a crate::cache::CacheItem);
     impl Drop for ReleaseGuard<'_> {

--- a/tests/cache_open_race_tests.rs
+++ b/tests/cache_open_race_tests.rs
@@ -1,0 +1,49 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use rd_rs::cache::Cache;
+use rd_rs::config::VfsConfig;
+
+#[tokio::test]
+async fn get_or_create_marks_open_before_return_to_avoid_eviction_race() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = Arc::new(VfsConfig::default());
+    let cache = Cache::new(tmp.path(), cfg);
+
+    // Create once, then age it out to be "idle-evictable".
+    let item = cache.get_or_create("ak", "f.bin", 10).unwrap();
+    item.release(); // balance open from get_or_create
+    item.set_atime_secs(0);
+
+    // Start a task that will acquire it and hold it open briefly.
+    let acquired = Arc::new(AtomicBool::new(false));
+    let acquired2 = Arc::clone(&acquired);
+    let cache2 = Arc::clone(&cache);
+    let (tx, rx) = tokio::sync::oneshot::channel::<usize>();
+    let t = tokio::spawn(async move {
+        let it = cache2.get_or_create("ak", "f.bin", 10).unwrap();
+        let _ = tx.send(Arc::as_ptr(&it) as usize);
+        acquired2.store(true, Ordering::Release);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        it.release();
+    });
+
+    // Wait until the task has acquired the item, then run eviction.
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !acquired.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    let held_ptr = rx.await.unwrap();
+    cache.evict_once();
+    let it2 = cache.get_or_create("ak", "f.bin", 10).unwrap();
+    let ptr2 = Arc::as_ptr(&it2) as usize;
+    assert_eq!(ptr2, held_ptr, "eviction removed an in-use cache item");
+    it2.release();
+
+    t.await.unwrap();
+}


### PR DESCRIPTION
This is part 10 of 11 in the cumulative PR chain. 

Current PR contains all architectural changes from part 1 up to 10 against `main`.