### PR TITLE
feat: block FUSE read() during in-flight repair (repair-wait)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "rd-rs"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rd-rs"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.94"
 description = "Rust rewrite of zurg — Real-Debrid FUSE filesystem server"

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,5 +3,11 @@ token = "YOUR_REAL_DEBRID_TOKEN"
 mount_path = "/mnt/rd"
 cache_dir = "/data/cache"
 
+[repair]
+# Seconds to block a FUSE read() waiting for in-flight repair to complete.
+# 0 = disabled (return ENOENT immediately, legacy behavior).
+# Default: 28 (just under typical HTTP stream client timeouts of 30 s).
+fuse_repair_wait_secs = 28
+
 [vfs]
 max_parallel_streams = 8

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -23,6 +23,9 @@ pub(super) fn default_head_check_min_interval_mins() -> u64 {
 pub(super) fn default_repair_batch_file_group_size() -> u32 {
     5
 }
+pub(super) fn default_fuse_repair_wait_secs() -> u64 {
+    28
+}
 pub(super) fn default_rate_limit() -> u32 {
     250
 }

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -78,6 +78,12 @@ pub struct RepairConfig {
     /// Max number of file IDs per Strategy 4 `select_torrent_files` batch (clamped 1–32).
     #[serde(default = "defaults::default_repair_batch_file_group_size")]
     pub batch_file_group_size: u32,
+
+    /// Seconds to block a FUSE read() waiting for in-flight repair to complete.
+    /// 0 = disabled (return ENOENT immediately, legacy behavior).
+    /// Default: 28 (just under typical HTTP stream client timeouts of 30 s).
+    #[serde(default = "defaults::default_fuse_repair_wait_secs")]
+    pub fuse_repair_wait_secs: u64,
 }
 
 impl Default for RepairConfig {
@@ -93,6 +99,7 @@ impl Default for RepairConfig {
             head_unreachable_threshold: 1,
             head_check_min_interval_mins: 30,
             batch_file_group_size: 5,
+            fuse_repair_wait_secs: 28,
         }
     }
 }

--- a/src/fuse/read.rs
+++ b/src/fuse/read.rs
@@ -23,6 +23,34 @@ use super::vfs_read_buffer::{PrepareRead, VfsReadBuffer, clamp_buffer_size};
 /// Max unrestrict+retry cycles per single `read()` call.
 const MAX_RETRIES: usize = 3;
 
+/// Block until `rx` transitions to `TorrentState::Ok`, the timeout elapses,
+/// or the FUSE operation is cancelled. Returns `true` only on `Ok`.
+async fn wait_for_repair_ok(
+    rx: &mut tokio::sync::watch::Receiver<crate::db::TorrentState>,
+    timeout: Duration,
+    cancel: &tokio_util::sync::CancellationToken,
+) -> bool {
+    if *rx.borrow() == crate::db::TorrentState::Ok {
+        return true;
+    }
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return false,
+            _ = &mut deadline      => return false,
+            result = rx.changed()  => {
+                match result {
+                    Err(_) => return false,
+                    Ok(()) if *rx.borrow() == crate::db::TorrentState::Ok => return true,
+                    Ok(()) => continue,
+                }
+            }
+        }
+    }
+}
+
 pub async fn read(
     fs: &RdFs,
     inode: u64,
@@ -33,7 +61,6 @@ pub async fn read(
     fuse_ctx: tokio_util::sync::CancellationToken,
 ) -> FuseResult<ReplyData> {
     // ── 1. Resolve inode → (torrent_index, file_index) ────────────────────────
-    // file_inode(ti, fi) = INODE_FILE_BASE + ti * 10_000 + fi
     let offset_from_base = inode
         .checked_sub(INODE_FILE_BASE)
         .ok_or(Errno::from(libc::ENOENT))?;
@@ -45,279 +72,321 @@ pub async fn read(
         .inode_to_access_key(torrent_inode)
         .ok_or(Errno::from(libc::ENOENT))?;
 
-    // ── 2. Ensure torrent info is loaded ──────────────────────────────────────
-    let mt = fs
-        .ensure_torrent_info(&access_key)
-        .await
-        .ok_or(Errno::from(libc::ENOENT))?;
-
-    let ti = mt.info.as_ref().ok_or(Errno::from(libc::ENOENT))?;
-    let selected: Vec<_> = ti.files.iter().filter(|f| f.is_selected()).collect();
-    let file = selected.get(file_idx).ok_or(Errno::from(libc::ENOENT))?;
-
-    let file_size = file.bytes as u64;
-    if file_size == 0 {
-        return Ok(ReplyData {
-            data: bytes::Bytes::new(),
-        });
-    }
-
-    if mt
-        .file_states
-        .as_ref()
-        .is_some_and(|fs| fs.get(&file.path).is_some_and(|s| s == "broken"))
-    {
-        let log_key = format!("{access_key}\x1f{}", file.path);
-        let now = Instant::now();
-        let emit = fs
-            .broken_read_warn_ts
-            .get(&log_key)
-            .map(|t| now.duration_since(*t.value()) >= Duration::from_secs(60))
-            .unwrap_or(true);
-        if emit {
-            fs.broken_read_warn_ts.insert(log_key, now);
-            tracing::warn!(
-                path = %file.path,
-                key = %access_key,
-                "fuse read: file marked broken in file_states (skipping unrestrict); clear with repair or edit DB if wrong"
-            );
-        } else {
-            tracing::debug!(
-                path = %file.path,
-                key = %access_key,
-                "fuse read: file marked broken, skip unrestrict"
-            );
-        }
-        return Err(Errno::from(libc::ENOENT));
-    }
-
-    // Pick the right link: torrent links are 1:1 with selected files.
-    let link_idx = file_idx.min(ti.links.len().saturating_sub(1));
-    let torrent_link = ti
-        .links
-        .get(link_idx)
-        .ok_or(Errno::from(libc::ENOENT))?
-        .clone();
-
-    // Build a stable cache filename from the file's path.
-    let filename = std::path::Path::new(&file.path)
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| format!("file_{file_idx}"));
-    let sanitized = sanitize_filename(&filename);
-
     let config = fs.config.load();
+    let wait_secs = config.repair.fuse_repair_wait_secs;
 
-    let cache_item = fs
-        .cache
-        .get_or_create(&access_key, &sanitized, file_size)
-        .map_err(|e| {
-            tracing::error!("cache get_or_create failed: {e:#}");
-            Errno::from(libc::EIO)
-        })?;
+    let mut repair_waited = false;
 
-    // Decrement on exit (regardless of success/failure path).
-    struct ReleaseGuard<'a>(&'a crate::cache::CacheItem);
-    impl Drop for ReleaseGuard<'_> {
-        fn drop(&mut self) {
-            self.0.release();
+    'read_retry: loop {
+        // ── 2. Ensure torrent info is loaded ──────────────────────────────────────
+        let mt = fs
+            .ensure_torrent_info(&access_key)
+            .await
+            .ok_or(Errno::from(libc::ENOENT))?;
+
+        let ti = mt.info.as_ref().ok_or(Errno::from(libc::ENOENT))?;
+        let selected: Vec<_> = ti.files.iter().filter(|f| f.is_selected()).collect();
+        let file = selected.get(file_idx).ok_or(Errno::from(libc::ENOENT))?;
+
+        let file_size = file.bytes as u64;
+        if file_size == 0 {
+            return Ok(ReplyData {
+                data: bytes::Bytes::new(),
+            });
         }
-    }
-    let _guard = ReleaseGuard(&cache_item);
 
-    let buffer_size = clamp_buffer_size(parse_byte_size(&config.vfs.buffer_size));
-
-    // Per-fd read window vs direct `read_at(offset, size)`.
-    enum FetchPlan {
-        Direct,
-        Buffered {
-            buf: std::sync::Arc<tokio::sync::Mutex<VfsReadBuffer>>,
-            take: u32,
-        },
-    }
-
-    let (read_off, read_len, plan) = 'fetch: {
-        if fh != 0
-            && let Some(ent) = fs.open_files.get(&fh)
+        // Check if file is marked broken
+        if mt
+            .file_states
+            .as_ref()
+            .is_some_and(|fs| fs.get(&file.path).is_some_and(|s| s == "broken"))
         {
-            let buf = std::sync::Arc::clone(&ent.value().buffer);
-            drop(ent);
-            let (fill_offset, fill_len, take) = {
-                let mut g = buf.lock().await;
-                match g.prepare_read(offset, size, file_size, buffer_size) {
-                    PrepareRead::Hit(data) => {
-                        tracing::trace!(
-                            inode,
-                            offset,
-                            bytes = data.len(),
-                            "fuse read: vfs buffer hit"
-                        );
-                        return Ok(ReplyData { data });
-                    }
-                    PrepareRead::Miss {
-                        fill_offset,
-                        fill_len,
-                        take,
-                    } => (fill_offset, fill_len, take),
+            if !repair_waited && wait_secs > 0 {
+                repair_waited = true;
+                let mut rx = fs.torrent_manager.subscribe_repair_state(&access_key);
+                fs.torrent_manager.enqueue_repair(access_key.clone()).await;
+                tracing::info!(path = %file.path,
+                    "fuse: file broken in file_states — waiting {wait_secs}s for repair");
+                if wait_for_repair_ok(&mut rx, Duration::from_secs(wait_secs), &fuse_ctx).await {
+                    tracing::info!(path = %file.path, "fuse: repair ok — retrying read");
+                    continue 'read_retry;
                 }
-            };
-            if fill_len == 0 {
-                return Ok(ReplyData { data: Bytes::new() });
             }
-            break 'fetch (fill_offset, fill_len, FetchPlan::Buffered { buf, take });
-        }
-        (offset, size, FetchPlan::Direct)
-    };
 
-    // ── 3. Retry loop : unrestrict → corrupted-link check → cache read ────────
-    for attempt in 0..=MAX_RETRIES {
-        if attempt > 0 {
-            tokio::time::sleep(std::time::Duration::from_secs(attempt as u64 * 2)).await;
-        }
-
-        let download = match fs.rd.unrestrict_link(unrestrict_cache, &torrent_link).await {
-            Ok(d) => d,
-            Err(e) => {
-                let is_fatal = match &e {
-                    crate::rd::client::RdError::Api(api_err) => !api_err.should_retry(),
-                    _ => false,
-                };
-
+            let log_key = format!("{access_key}\x1f{}", file.path);
+            let now = Instant::now();
+            let emit = fs
+                .broken_read_warn_ts
+                .get(&log_key)
+                .map(|t| now.duration_since(*t.value()) >= Duration::from_secs(60))
+                .unwrap_or(true);
+            if emit {
+                fs.broken_read_warn_ts.insert(log_key, now);
                 tracing::warn!(
-                    attempt,
-                    link = %torrent_link,
-                    is_fatal,
-                    "unrestrict failed: {e:#}"
+                    path = %file.path,
+                    key = %access_key,
+                    "fuse read: file marked broken in file_states (skipping unrestrict); clear with repair or edit DB if wrong"
                 );
-
-                if is_fatal {
-                    tracing::error!(link = %torrent_link, "fatal unrestrict error, queuing repair");
-                    // Drop all token buckets for this RD link, then on-disk ranges, before marking
-                    // broken and enqueueing repair (zurg-style ordering: no stale VFS after repair).
-                    clear_unrestrict_cache_for_source_link(unrestrict_cache, &torrent_link);
-                    fs.cache.invalidate(&access_key, &sanitized);
-                    let tm = fs.torrent_manager.clone();
-                    let ak = access_key.clone();
-                    let file_path = file.path.clone();
-                    if !tm.fuse_begin_fatal_read_repair(&ak, &file_path).await {
-                        return Err(Errno::from(libc::ENOENT));
-                    }
-                    async {
-                        // `unrepairable_reason` is for cascade “won’t fix” outcomes; if we set it here,
-                        // [`RepairEngine::repair_one_torrent`] skips the torrent entirely (no repair run).
-                        if let Err(err) = tm
-                            .update_torrent_state(&ak, crate::db::TorrentState::Broken, None)
-                            .await
-                        {
-                            tracing::error!(
-                                "Failed to set Broken after fatal unrestrict for {}: {}",
-                                ak,
-                                err
-                            );
-                        }
-                        let _ = tm.mark_file_broken(&ak, &file_path).await;
-                        tm.enqueue_repair(ak.clone()).await;
-                    }
-                    .await;
-                    tm.fuse_end_fatal_read_repair(&ak, &file_path).await;
-                    return Err(Errno::from(libc::ENOENT));
-                }
-
-                continue;
+            } else {
+                tracing::debug!(
+                    path = %file.path,
+                    key = %access_key,
+                    "fuse read: file marked broken, skip unrestrict"
+                );
             }
-        };
-
-        let path_ext = std::path::Path::new(&file.path)
-            .extension()
-            .and_then(|e| e.to_str())
-            .map(|s| s.to_ascii_lowercase());
-        let dl_ext = download.extension().map(|s| s.to_ascii_lowercase());
-
-        // Corrupted-link detection (commit 00ed4714):
-        // filesize mismatch AND extension mismatch → bad link, not just a CDN redirect.
-        if download.filesize != 0
-            && download.filesize as u64 != file_size
-            && dl_ext.as_deref() != path_ext.as_deref()
-        {
-            tracing::warn!(
-                link = %torrent_link,
-                rd_size = download.filesize,
-                expected = file_size,
-                "corrupted link detected — clearing unrestrict cache and VFS disk cache, queuing repair"
-            );
-            clear_unrestrict_cache(unrestrict_cache, &download.token, &torrent_link);
-            fs.cache.invalidate(&access_key, &sanitized);
-
-            let tm = fs.torrent_manager.clone();
-            let ak = access_key.clone();
-            let file_path = file.path.clone();
-            if !tm.fuse_begin_fatal_read_repair(&ak, &file_path).await {
-                return Err(Errno::from(libc::ENOENT));
-            }
-            async {
-                if let Err(e) = tm
-                    .update_torrent_state(&ak, crate::db::TorrentState::Broken, None)
-                    .await
-                {
-                    tracing::error!(
-                        "Failed to set Broken after corrupted link for {}: {}",
-                        ak,
-                        e
-                    );
-                }
-                let _ = tm.mark_file_broken(&ak, &file_path).await;
-                tm.enqueue_repair(ak.clone()).await;
-            }
-            .await;
-            tm.fuse_end_fatal_read_repair(&ak, &file_path).await;
-
             return Err(Errno::from(libc::ENOENT));
         }
 
-        match cache_item
-            .read_at(
-                fuse_ctx.clone(),
-                read_off,
-                read_len,
-                &download,
-                &fs.rd,
-                unrestrict_cache,
-                &config,
-                fs.cache.pause_downloads.subscribe(),
-            )
-            .await
-        {
-            Ok(filled) => {
-                let data = match &plan {
-                    FetchPlan::Direct => filled,
-                    FetchPlan::Buffered { buf, take } => {
-                        let mut g = buf.lock().await;
-                        let reply_len = (*take as usize).min(filled.len());
-                        let reply = filled.slice(0..reply_len);
-                        g.after_fetch(read_off, filled, *take);
-                        reply
-                    }
-                };
-                tracing::trace!(inode, offset, bytes = data.len(), "fuse read: served");
-                return Ok(ReplyData { data });
-            }
-            Err(CacheReadError::Cancelled) => {
-                return Err(Errno::from(libc::EINTR));
-            }
-            Err(CacheReadError::DownloadFailed) => {
-                clear_unrestrict_cache(unrestrict_cache, &download.token, &torrent_link);
-                tracing::warn!(attempt, inode, offset, "download failed — retrying");
-                continue;
-            }
-            Err(CacheReadError::Io(e)) => {
-                tracing::error!(inode, offset, "read_at IO error: {e:#}");
-                return Err(Errno::from(libc::EIO));
+        // Pick the right link: torrent links are 1:1 with selected files.
+        let link_idx = file_idx.min(ti.links.len().saturating_sub(1));
+        let torrent_link = ti
+            .links
+            .get(link_idx)
+            .ok_or(Errno::from(libc::ENOENT))?
+            .clone();
+
+        // Build a stable cache filename from the file's path.
+        let filename = std::path::Path::new(&file.path)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| format!("file_{file_idx}"));
+        let sanitized = sanitize_filename(&filename);
+
+        let cache_item = fs
+            .cache
+            .get_or_create(&access_key, &sanitized, file_size)
+            .map_err(|e| {
+                tracing::error!("cache get_or_create failed: {e:#}");
+                Errno::from(libc::EIO)
+            })?;
+
+        // Decrement on exit (regardless of success/failure path).
+        struct ReleaseGuard<'a>(&'a crate::cache::CacheItem);
+        impl Drop for ReleaseGuard<'_> {
+            fn drop(&mut self) {
+                self.0.release();
             }
         }
-    }
+        let _guard = ReleaseGuard(&cache_item);
 
-    tracing::error!(inode, "read: all {MAX_RETRIES} retries exhausted");
-    Err(Errno::from(libc::EIO))
+        let buffer_size = clamp_buffer_size(parse_byte_size(&config.vfs.buffer_size));
+
+        // Per-fd read window vs direct `read_at(offset, size)`.
+        enum FetchPlan {
+            Direct,
+            Buffered {
+                buf: std::sync::Arc<tokio::sync::Mutex<VfsReadBuffer>>,
+                take: u32,
+            },
+        }
+
+        let (read_off, read_len, plan) = 'fetch: {
+            if fh != 0
+                && let Some(ent) = fs.open_files.get(&fh)
+            {
+                let buf = std::sync::Arc::clone(&ent.value().buffer);
+                drop(ent);
+                let (fill_offset, fill_len, take) = {
+                    let mut g = buf.lock().await;
+                    match g.prepare_read(offset, size, file_size, buffer_size) {
+                        PrepareRead::Hit(data) => {
+                            tracing::trace!(
+                                inode,
+                                offset,
+                                bytes = data.len(),
+                                "fuse read: vfs buffer hit"
+                            );
+                            return Ok(ReplyData { data });
+                        }
+                        PrepareRead::Miss {
+                            fill_offset,
+                            fill_len,
+                            take,
+                        } => (fill_offset, fill_len, take),
+                    }
+                };
+                if fill_len == 0 {
+                    return Ok(ReplyData { data: Bytes::new() });
+                }
+                break 'fetch (fill_offset, fill_len, FetchPlan::Buffered { buf, take });
+            }
+            (offset, size, FetchPlan::Direct)
+        };
+
+        // ── 3. Retry loop : unrestrict → corrupted-link check → cache read ────────
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                tokio::time::sleep(std::time::Duration::from_secs(attempt as u64 * 2)).await;
+            }
+
+            let download = match fs.rd.unrestrict_link(unrestrict_cache, &torrent_link).await {
+                Ok(d) => d,
+                Err(e) => {
+                    let is_fatal = match &e {
+                        crate::rd::client::RdError::Api(api_err) => !api_err.should_retry(),
+                        _ => false,
+                    };
+
+                    tracing::warn!(
+                        attempt,
+                        link = %torrent_link,
+                        is_fatal,
+                        "unrestrict failed: {e:#}"
+                    );
+
+                    if is_fatal {
+                        tracing::error!(link = %torrent_link, "fatal unrestrict error, queuing repair");
+                        clear_unrestrict_cache_for_source_link(unrestrict_cache, &torrent_link);
+                        fs.cache.invalidate(&access_key, &sanitized);
+                        let tm = fs.torrent_manager.clone();
+                        let ak = access_key.clone();
+                        let file_path = file.path.clone();
+                        if !tm.fuse_begin_fatal_read_repair(&ak, &file_path).await {
+                            return Err(Errno::from(libc::ENOENT));
+                        }
+                        async {
+                            if let Err(err) = tm
+                                .update_torrent_state(&ak, crate::db::TorrentState::Broken, None)
+                                .await
+                            {
+                                tracing::error!(
+                                    "Failed to set Broken after fatal unrestrict for {}: {}",
+                                    ak,
+                                    err
+                                );
+                            }
+                            let _ = tm.mark_file_broken(&ak, &file_path).await;
+                            tm.enqueue_repair(ak.clone()).await;
+                        }
+                        .await;
+                        tm.fuse_end_fatal_read_repair(&ak, &file_path).await;
+
+                        if !repair_waited && wait_secs > 0 {
+                            repair_waited = true;
+                            let mut rx = fs.torrent_manager.subscribe_repair_state(&access_key);
+                            tracing::info!(
+                                "fuse: fatal unrestrict — waiting {wait_secs}s for repair"
+                            );
+                            if wait_for_repair_ok(
+                                &mut rx,
+                                Duration::from_secs(wait_secs),
+                                &fuse_ctx,
+                            )
+                            .await
+                            {
+                                tracing::info!("fuse: repair ok — retrying read");
+                                continue 'read_retry;
+                            }
+                        }
+                        return Err(Errno::from(libc::ENOENT));
+                    }
+
+                    continue;
+                }
+            };
+
+            let path_ext = std::path::Path::new(&file.path)
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|s| s.to_ascii_lowercase());
+            let dl_ext = download.extension().map(|s| s.to_ascii_lowercase());
+
+            // Corrupted-link detection (commit 00ed4714):
+            // filesize mismatch AND extension mismatch → bad link, not just a CDN redirect.
+            if download.filesize != 0
+                && download.filesize as u64 != file_size
+                && dl_ext.as_deref() != path_ext.as_deref()
+            {
+                tracing::warn!(
+                    link = %torrent_link,
+                    rd_size = download.filesize,
+                    expected = file_size,
+                    "corrupted link detected — clearing unrestrict cache and VFS disk cache, queuing repair"
+                );
+                clear_unrestrict_cache(unrestrict_cache, &download.token, &torrent_link);
+                fs.cache.invalidate(&access_key, &sanitized);
+
+                let tm = fs.torrent_manager.clone();
+                let ak = access_key.clone();
+                let file_path = file.path.clone();
+                if !tm.fuse_begin_fatal_read_repair(&ak, &file_path).await {
+                    return Err(Errno::from(libc::ENOENT));
+                }
+                async {
+                    if let Err(e) = tm
+                        .update_torrent_state(&ak, crate::db::TorrentState::Broken, None)
+                        .await
+                    {
+                        tracing::error!(
+                            "Failed to set Broken after corrupted link for {}: {}",
+                            ak,
+                            e
+                        );
+                    }
+                    let _ = tm.mark_file_broken(&ak, &file_path).await;
+                    tm.enqueue_repair(ak.clone()).await;
+                }
+                .await;
+                tm.fuse_end_fatal_read_repair(&ak, &file_path).await;
+
+                if !repair_waited && wait_secs > 0 {
+                    repair_waited = true;
+                    let mut rx = fs.torrent_manager.subscribe_repair_state(&access_key);
+                    tracing::info!("fuse: corrupted link — waiting {wait_secs}s for repair");
+                    if wait_for_repair_ok(&mut rx, Duration::from_secs(wait_secs), &fuse_ctx).await
+                    {
+                        tracing::info!("fuse: repair ok - retrying read");
+                        continue 'read_retry;
+                    }
+                }
+                return Err(Errno::from(libc::ENOENT));
+            }
+
+            match cache_item
+                .read_at(
+                    fuse_ctx.clone(),
+                    read_off,
+                    read_len,
+                    &download,
+                    &fs.rd,
+                    unrestrict_cache,
+                    &config,
+                    fs.cache.pause_downloads.subscribe(),
+                )
+                .await
+            {
+                Ok(filled) => {
+                    let data = match &plan {
+                        FetchPlan::Direct => filled,
+                        FetchPlan::Buffered { buf, take } => {
+                            let mut g = buf.lock().await;
+                            let reply_len = (*take as usize).min(filled.len());
+                            let reply = filled.slice(0..reply_len);
+                            g.after_fetch(read_off, filled, *take);
+                            reply
+                        }
+                    };
+                    tracing::trace!(inode, offset, bytes = data.len(), "fuse read: served");
+                    return Ok(ReplyData { data });
+                }
+                Err(CacheReadError::Cancelled) => {
+                    return Err(Errno::from(libc::EINTR));
+                }
+                Err(CacheReadError::DownloadFailed) => {
+                    clear_unrestrict_cache(unrestrict_cache, &download.token, &torrent_link);
+                    tracing::warn!(attempt, inode, offset, "download failed — retrying");
+                    continue;
+                }
+                Err(CacheReadError::Io(e)) => {
+                    tracing::error!(inode, offset, "read_at IO error: {e:#}");
+                    return Err(Errno::from(libc::EIO));
+                }
+            }
+        }
+
+        tracing::error!(inode, "read: all {MAX_RETRIES} retries exhausted");
+        return Err(Errno::from(libc::EIO));
+    }
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/src/fuse/read.rs
+++ b/src/fuse/read.rs
@@ -43,8 +43,16 @@ async fn wait_for_repair_ok(
             result = rx.changed()  => {
                 match result {
                     Err(_) => return false,
-                    Ok(()) if *rx.borrow() == crate::db::TorrentState::Ok => return true,
-                    Ok(()) => continue,
+                    Ok(()) => {
+                        let state = rx.borrow().clone();
+                        if state == crate::db::TorrentState::Ok {
+                            return true;
+                        }
+                        if state == crate::db::TorrentState::Broken {
+                            return false;
+                        }
+                        continue;
+                    }
                 }
             }
         }
@@ -241,29 +249,43 @@ pub async fn read(
                         let tm = fs.torrent_manager.clone();
                         let ak = access_key.clone();
                         let file_path = file.path.clone();
-                        if !tm.fuse_begin_fatal_read_repair(&ak, &file_path).await {
-                            return Err(Errno::from(libc::ENOENT));
-                        }
-                        async {
-                            if let Err(err) = tm
-                                .update_torrent_state(&ak, crate::db::TorrentState::Broken, None)
-                                .await
-                            {
-                                tracing::error!(
-                                    "Failed to set Broken after fatal unrestrict for {}: {}",
-                                    ak,
-                                    err
-                                );
-                            }
-                            let _ = tm.mark_file_broken(&ak, &file_path).await;
-                            tm.enqueue_repair(ak.clone()).await;
-                        }
-                        .await;
-                        tm.fuse_end_fatal_read_repair(&ak, &file_path).await;
+                        let is_repair_leader =
+                            tm.fuse_begin_fatal_read_repair(&ak, &file_path).await;
 
-                        if !repair_waited && wait_secs > 0 {
+                        let rx = if !repair_waited && wait_secs > 0 {
+                            Some(fs.torrent_manager.subscribe_repair_state(&access_key))
+                        } else {
+                            None
+                        };
+
+                        if is_repair_leader {
+                            async {
+                                if let Err(err) = tm
+                                    .update_torrent_state(
+                                        &ak,
+                                        crate::db::TorrentState::Broken,
+                                        None,
+                                    )
+                                    .await
+                                {
+                                    tracing::error!(
+                                        "Failed to set Broken after fatal unrestrict for {}: {}",
+                                        ak,
+                                        err
+                                    );
+                                }
+                                let _ = tm.mark_file_broken(&ak, &file_path).await;
+                                tm.enqueue_repair(ak.clone()).await;
+                            }
+                            .await;
+                            tm.fuse_end_fatal_read_repair(&ak, &file_path).await;
+                        }
+
+                        if !repair_waited
+                            && wait_secs > 0
+                            && let Some(mut rx) = rx
+                        {
                             repair_waited = true;
-                            let mut rx = fs.torrent_manager.subscribe_repair_state(&access_key);
                             tracing::info!(
                                 "fuse: fatal unrestrict — waiting {wait_secs}s for repair"
                             );
@@ -309,29 +331,38 @@ pub async fn read(
                 let tm = fs.torrent_manager.clone();
                 let ak = access_key.clone();
                 let file_path = file.path.clone();
-                if !tm.fuse_begin_fatal_read_repair(&ak, &file_path).await {
-                    return Err(Errno::from(libc::ENOENT));
-                }
-                async {
-                    if let Err(e) = tm
-                        .update_torrent_state(&ak, crate::db::TorrentState::Broken, None)
-                        .await
-                    {
-                        tracing::error!(
-                            "Failed to set Broken after corrupted link for {}: {}",
-                            ak,
-                            e
-                        );
-                    }
-                    let _ = tm.mark_file_broken(&ak, &file_path).await;
-                    tm.enqueue_repair(ak.clone()).await;
-                }
-                .await;
-                tm.fuse_end_fatal_read_repair(&ak, &file_path).await;
+                let is_repair_leader = tm.fuse_begin_fatal_read_repair(&ak, &file_path).await;
 
-                if !repair_waited && wait_secs > 0 {
+                let rx = if !repair_waited && wait_secs > 0 {
+                    Some(fs.torrent_manager.subscribe_repair_state(&access_key))
+                } else {
+                    None
+                };
+
+                if is_repair_leader {
+                    async {
+                        if let Err(e) = tm
+                            .update_torrent_state(&ak, crate::db::TorrentState::Broken, None)
+                            .await
+                        {
+                            tracing::error!(
+                                "Failed to set Broken after corrupted link for {}: {}",
+                                ak,
+                                e
+                            );
+                        }
+                        let _ = tm.mark_file_broken(&ak, &file_path).await;
+                        tm.enqueue_repair(ak.clone()).await;
+                    }
+                    .await;
+                    tm.fuse_end_fatal_read_repair(&ak, &file_path).await;
+                }
+
+                if !repair_waited
+                    && wait_secs > 0
+                    && let Some(mut rx) = rx
+                {
                     repair_waited = true;
-                    let mut rx = fs.torrent_manager.subscribe_repair_state(&access_key);
                     tracing::info!("fuse: corrupted link — waiting {wait_secs}s for repair");
                     if wait_for_repair_ok(&mut rx, Duration::from_secs(wait_secs), &fuse_ctx).await
                     {

--- a/src/fuse/read.rs
+++ b/src/fuse/read.rs
@@ -44,12 +44,8 @@ async fn wait_for_repair_ok(
                 match result {
                     Err(_) => return false,
                     Ok(()) => {
-                        let state = rx.borrow().clone();
-                        if state == crate::db::TorrentState::Ok {
+                        if rx.borrow().clone() == crate::db::TorrentState::Ok {
                             return true;
-                        }
-                        if state == crate::db::TorrentState::Broken {
-                            return false;
                         }
                         continue;
                     }

--- a/src/torrent/mod.rs
+++ b/src/torrent/mod.rs
@@ -304,6 +304,11 @@ impl TorrentManager {
             .value()
             .clone();
 
+        // Re-sync with latest state to close race condition window between initial get and channel creation.
+        if let Some(m) = self.torrents.get(access_key) {
+            let _ = tx.send(m.state.clone());
+        }
+
         tx.subscribe()
     }
 

--- a/src/torrent/mod.rs
+++ b/src/torrent/mod.rs
@@ -291,23 +291,18 @@ impl TorrentManager {
         &self,
         access_key: &str,
     ) -> tokio::sync::watch::Receiver<TorrentState> {
+        let current = self
+            .torrents
+            .get(access_key)
+            .map(|m| m.state.clone())
+            .unwrap_or(TorrentState::Broken);
+
         let tx = self
             .repair_state_tx
             .entry(access_key.to_string())
-            .or_insert_with(|| {
-                let current = self
-                    .torrents
-                    .get(access_key)
-                    .map(|m| m.state.clone())
-                    .unwrap_or(TorrentState::Broken);
-                Arc::new(tokio::sync::watch::channel(current).0)
-            })
+            .or_insert_with(|| Arc::new(tokio::sync::watch::channel(current).0))
             .value()
             .clone();
-
-        if let Some(m) = self.torrents.get(access_key) {
-            let _ = tx.send(m.state.clone());
-        }
 
         tx.subscribe()
     }

--- a/src/torrent/mod.rs
+++ b/src/torrent/mod.rs
@@ -291,16 +291,23 @@ impl TorrentManager {
         &self,
         access_key: &str,
     ) -> tokio::sync::watch::Receiver<TorrentState> {
-        let current = self
-            .torrents
-            .get(access_key)
-            .map(|m| m.state.clone())
-            .unwrap_or(TorrentState::Broken);
-
         let tx = self
             .repair_state_tx
             .entry(access_key.to_string())
-            .or_insert_with(|| Arc::new(tokio::sync::watch::channel(current).0));
+            .or_insert_with(|| {
+                let current = self
+                    .torrents
+                    .get(access_key)
+                    .map(|m| m.state.clone())
+                    .unwrap_or(TorrentState::Broken);
+                Arc::new(tokio::sync::watch::channel(current).0)
+            })
+            .value()
+            .clone();
+
+        if let Some(m) = self.torrents.get(access_key) {
+            let _ = tx.send(m.state.clone());
+        }
 
         tx.subscribe()
     }

--- a/src/torrent/mod.rs
+++ b/src/torrent/mod.rs
@@ -8,7 +8,7 @@
 //! ## `file_states` concurrency
 //!
 //! All mutations to [`ManagedTorrent::file_states`] go through `TorrentManager` (`mark_file_broken`,
-//! `persist_torrent_snapshot`, refresh merge, repair preflight). We do not model zurg’s per-file
+//! `persist_torrent_snapshot`, refresh merge, repair preflight). We do not model zurg's per-file
 //! FSM mutex graph; a single writer discipline keeps FUSE, refresh, and repair consistent.
 
 mod fuse_read_coalesce;
@@ -131,8 +131,12 @@ pub struct TorrentManager {
 
     pub(crate) repair_queue: Arc<Mutex<VecDeque<String>>>,
 
-    /// One in-flight “fatal read → mark broken + enqueue repair” handler per `(access_key, file_path)`.
+    /// One in-flight "fatal read → mark broken + enqueue repair" handler per `(access_key, file_path)`.
     pub(crate) fuse_fatal_read_locks: Arc<Mutex<HashSet<(String, String)>>>,
+
+    /// Per-torrent watch channel — fires on every state change.
+    /// FUSE repair-waiters subscribe here instead of polling.
+    pub(crate) repair_state_tx: DashMap<String, Arc<tokio::sync::watch::Sender<TorrentState>>>,
 }
 
 impl TorrentManager {
@@ -151,6 +155,7 @@ impl TorrentManager {
         let repair_notify = Arc::new(Notify::new());
         let repair_queue = Arc::new(Mutex::new(VecDeque::new()));
         let fuse_fatal_read_locks = Arc::new(Mutex::new(HashSet::new()));
+        let repair_state_tx = DashMap::new();
 
         let mgr = Self {
             torrents,
@@ -164,6 +169,7 @@ impl TorrentManager {
             repair_notify,
             repair_queue,
             fuse_fatal_read_locks,
+            repair_state_tx,
         };
 
         // Warm from SQLite before first RD sync (< 1s for 20K rows)
@@ -276,6 +282,27 @@ impl TorrentManager {
 
     pub fn cancel_token(&self) -> CancellationToken {
         self.shutdown.clone()
+    }
+
+    /// Subscribe to state changes for a torrent.
+    /// Returns a Receiver initialised with its current state.
+    /// Creates the sender lazily if not yet present.
+    pub fn subscribe_repair_state(
+        &self,
+        access_key: &str,
+    ) -> tokio::sync::watch::Receiver<TorrentState> {
+        let current = self
+            .torrents
+            .get(access_key)
+            .map(|m| m.state.clone())
+            .unwrap_or(TorrentState::Broken);
+
+        let tx = self
+            .repair_state_tx
+            .entry(access_key.to_string())
+            .or_insert_with(|| Arc::new(tokio::sync::watch::channel(current).0));
+
+        tx.subscribe()
     }
 
     /// Load `TorrentInfo` for this key if missing (FUSE / repair).

--- a/src/torrent/refresh/mod.rs
+++ b/src/torrent/refresh/mod.rs
@@ -235,6 +235,7 @@ async fn run_once(mgr: &TorrentManager) -> anyhow::Result<()> {
         }
         changed_paths.push(format!("__all__/{}", key));
         mgr.torrents.remove(key);
+        mgr.repair_state_tx.remove(key);
     }
 
     if !to_upsert.is_empty() {

--- a/src/torrent/state_ops.rs
+++ b/src/torrent/state_ops.rs
@@ -137,6 +137,11 @@ impl TorrentManager {
             .map_err(|e| anyhow::anyhow!("DB update error: {}", e))?;
 
             self.trigger_library_update(self.library_paths_for(&updated));
+
+            // Unblock any FUSE repair-waiters on this torrent.
+            if let Some(tx) = self.repair_state_tx.get(access_key) {
+                let _ = tx.send(new_state.clone());
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
When rd-rs detects a broken/corrupted link during a FUSE read(), instead of returning ENOENT immediately, pause the FUSE reply and wait up to N seconds for the repair engine to finish. If repair succeeds within the window, retry the read transparently. All repair strategies run in parallel — including ReinsertTorrent — and whichever finishes first unblocks the read. If the timeout expires, ENOENT is returned as before (legacy behavior).

- Add `fuse_repair_wait_secs` field to `RepairConfig` (default: 28 seconds)
- Set to 0 to disable (return ENOENT immediately)
- Updated config.example.toml with documentation

- Add `repair_state_tx: DashMap<String, Arc<watch::Sender<TorrentState>>>` field for per-torrent watch channels
- Add `subscribe_repair_state(&self, access_key: &str)` method to subscribe to repair state changes
- Initialize the DashMap in `new()` and initialize in new method

- Add `wait_for_repair_ok()` helper that blocks until repair completes or timeout
- Wrap `read()` body in `'read_retry` loop to retry after successful repair
- On broken file state: subscribe, enqueue repair, wait (if enabled)
- On fatal unrestrict error: subscribe, wait (if enabled), retry on success
- On corrupted link detection: subscribe, wait (if enabled), retry on success
- Each repair-wait sets `repair_waited = true` to prevent duplicate waits per call

- Fire watch channel `send()` in `update_torrent_state()` to unblock all concurrent repair-waiters on that torrent

- Repair always runs in the existing parallel repair engine task
- Watch channel subscriptions happen BEFORE enqueue to avoid race conditions
- `continue 'read_retry` naturally re-fetches TorrentInfo because `replace_rd_ids_after_repair` cleared `info: None`
- Secondary readers coalesce via `fuse_begin_fatal_read_repair` returning false (no duplicate enqueue), but all readers wait on same watch channel
- FUSE cancellation token properly terminates wait
- ReleaseGuard (cache_item) drops cleanly at continue point (RAII)